### PR TITLE
tests: add a CDT smoke suite covering the ducktape image dependencies

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -249,10 +249,6 @@ class OpenMessagingBenchmark(Service):
             self.workload["payload_file"] = OpenMessagingBenchmark.CUSTOM_PAYLOAD_DIR
             self.workload["message_size"] = local_payload_dir.payload_size
 
-        assert int(self.workload.get("warmup_duration_minutes", "0")) >= 1, (
-            "must use non-zero warmup time as we rely on warm-up message to detect test start"
-        )
-
         self.logger.info(
             "Using driver: %s, workload: %s", self.driver["name"], self.workload["name"]
         )
@@ -348,8 +344,12 @@ class OpenMessagingBenchmark(Service):
             OpenMessagingBenchmark.STDOUT_STDERR_CAPTURE
         ) as monitor:
             node.account.ssh(start_cmd)
+            # OMB logs a banner when it begins each traffic phase. This
+            # pattern matches both the warm-up and the benchmark banner, so
+            # workloads with no warm-up phase are detected too. It is passed
+            # to grep, so it is a basic regex.
             monitor.wait_until(
-                "Starting warm-up traffic",
+                "Starting .* traffic",
                 timeout_sec=timeout_sec,
                 backoff_sec=4,
                 err_msg="Open Messaging Benchmark service didn't start",

--- a/tests/rptest/services/openmessaging_benchmark_configs.py
+++ b/tests/rptest/services/openmessaging_benchmark_configs.py
@@ -135,6 +135,26 @@ class OMBSampleConfigurations:
         return is_valid, results
 
     # ------ Driver configurations --------
+    # Single-broker driver for the CDT smoke suite: RF=1 so the workload can
+    # run against a one node cluster.
+    SMOKE_DRIVER_RF1 = {
+        "name": "smoke-driver-rf1",
+        "replication_factor": 1,
+        "request_timeout": 300000,
+        "producer_config": {
+            "enable.idempotence": "false",
+            "acks": "1",
+            "linger.ms": 1,
+            "max.in.flight.requests.per.connection": 1,
+            "batch.size": 131072,
+        },
+        "consumer_config": {
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": "false",
+            "max.partition.fetch.bytes": 131072,
+        },
+    }
+
     SIMPLE_DRIVER = {
         "name": "simple-driver",
         "replication_factor": 3,
@@ -260,6 +280,22 @@ class OMBSampleConfigurations:
         "warmup_duration_minutes": 5,
     }
 
+    # Smallest workload that still exercises the whole OMB pipeline
+    # (producer and consumer). No warmup phase, so the run is one minute
+    # instead of two.
+    SMOKE_WORKLOAD: dict[str, Any] = {
+        "name": "Smoke-workload-config",
+        "topics": 1,
+        "partitions_per_topic": 1,
+        "subscriptions_per_topic": 1,
+        "consumer_per_subscription": 1,
+        "producers_per_topic": 1,
+        "producer_rate": 100,
+        "consumer_backlog_size_GB": 0,
+        "test_duration_minutes": 1,
+        "warmup_duration_minutes": 0,
+    }
+
     SIMPLE_WORKLOAD: dict[str, Any] = {
         "name": "Simple-workload-config",
         "topics": 1,
@@ -311,6 +347,7 @@ class OMBSampleConfigurations:
     # driver and workload combination.
     DRIVERS: dict[str, dict[str, Any]] = {
         "SIMPLE_DRIVER": SIMPLE_DRIVER,
+        "SMOKE_DRIVER_RF1": SMOKE_DRIVER_RF1,
         "ACK_ALL_GROUP_LINGER_1MS": ACK_ALL_GROUP_LINGER_1MS,
         "ACK_ALL_GROUP_LINGER_1MS_WITH_IDEMPOTENCE": ACK_ALL_GROUP_LINGER_1MS_WITH_IDEMPOTENCE,
         "ACK_ALL_GROUP_LINGER_1MS_IDEM_MAX_IN_FLIGHT": ACK_ALL_GROUP_LINGER_1MS_IDEM_MAX_IN_FLIGHT,
@@ -322,6 +359,7 @@ class OMBSampleConfigurations:
     # metric validator.
     WORKLOADS = {
         "SIMPLE_WORKLOAD": (SIMPLE_WORKLOAD, UNIT_TEST_LATENCY_VALIDATOR),
+        "SMOKE_WORKLOAD": (SMOKE_WORKLOAD, UNIT_TEST_LATENCY_VALIDATOR),
         "DEDICATED_NODE_WORKLOAD": (
             DEDICATED_NODE_WORKLOAD,
             UNIT_TEST_LATENCY_VALIDATOR,

--- a/tests/rptest/test_suite_cdt_smoke.yml
+++ b/tests/rptest/test_suite_cdt_smoke.yml
@@ -1,0 +1,46 @@
+# CDT smoke suite.
+#
+# One cheap test per dependency installed into the ducktape test image, so a
+# CDT job can prove the image and rig still work without running a full
+# nightly. The comment on each entry names the ducktape-deps script (see
+# tests/docker/ducktape-deps/, installed by vtools qa/image/packer/install-deps.sh)
+# that the entry exercises.
+#
+# Tests were picked by cost, defined as runtime times nodes allocated, taken
+# from a full GCP nightly run and then confirmed on CDT. Prefer a purpose
+# built self test where one exists: it fails legibly when the dependency
+# breaks, which is the entire point of this suite.
+#
+# Keep this list minimal. Every entry should be the cheapest test that still
+# fails when its dependency is broken.
+cdt_smoke:
+  included:
+    - tests/quota_management_test.py::QuotaManagementTest.test_multiple_quotas_same_key@{"strict":false}   # kafka-tools, kcl
+    - tests/compatibility/sarama_produce_test.py::SaramaLegacyProduceTest.test_produce@{"compression_type":"lz4","validation_mode":"strict"}   # golang-test-clients, kcat
+    - tests/rpk_plugin_test.py::RpkPluginTest.test_non_managed_plugin   # plugin-mock
+    - tests/rpk_plugin_test.py::RpkPluginTest.test_managed_byoc   # byoc-mock
+    - tests/canary_benchmark_service_test.py::CanaryBenchmarkServiceSelfTest.test_stress_ng_smoke   # tool-pkgs (stress-ng)
+    - tests/canary_benchmark_service_test.py::CanaryBenchmarkServiceSelfTest.test_fio_smoke   # tool-pkgs (fio)
+    - transactions/idempotency_test.py::IdempotentProducerRecoveryTest.test_librdkafka_recovery_on_producer_eviction   # librdkafka, python-deps (confluent-kafka)
+    - tests/services_self_test.py::RedpandaServiceSelfTest.test_backtrace@{"simple_backtrace":true}   # addr2line, tool-pkgs (llvm-addr2line)
+    - tests/broker_side_compression_test.py::BrokerSideCompressionTest.test_java_producer_recompression@{"producer_codec":"zstd","topic_codec":"snappy"}   # java-verifiers, java-dev-tools
+    - tests/redpanda_kerberos_test.py::RedpandaKerberosRulesTesting.test_invalid_kerberos_mapping_rules@{"expected_error":"RUL","rules":["RULE:[1:$1]","RUL"]}   # tool-pkgs (krb5)
+    - tests/datalake/iceberg_rest_catalog_smoke_test.py::IcebergRESTCatalogSmokeTest.test_redpanda_schema@{"cloud_storage_type":1,"filesystem_catalog_mode":false}   # iceberg-rest-catalog, polaris, nessie
+    - tests/services_self_test.py::KubectlSelfTest.test_kubectl_tool   # k8s
+    - tests/compatibility/sarama_test.py::SaramaScramTest.test_sarama_sasl_scram@{"version":"2.6.0"}   # sarama-examples, golang
+    - tests/services_self_test.py::KgoVerifierSelfTest.test_kgo_verifier   # kgo-verifier-build
+    - tests/data_transforms_test.py::DataTransformsTest.test_consume_junk_off@{"offset":"__current_time__"}   # tinygo, tinygo-wasi-transforms
+    - tests/audit_log_test.py::AuditLogTestAdminApi.test_audit_log_metrics@{"audit_transport_mode":"rpc"}   # ocsf-server
+    - tests/tls_metrics_test.py::TLSMetricsTest.test_metrics   # tool-pkgs (faketime)
+    - tests/schema_registry_test.py::SchemaRegistryTest.test_nodejs_serde_client   # nodejs, nodejs-test-clients
+    - tests/services_self_test.py::ProducerSwarmSelfTest.test_wait_start_stop   # rust, client-swarm
+    - tests/datalake/spark_sql_server_smoke_test.py::SparkSmokeTest.test_spark_smoke@{"cloud_storage_type":1}   # spark
+    - tests/wait_for_local_consumer_test.py::WaitForLocalConsumerTest.test_wait_for_local_consumer   # kaf
+    - tests/datalake/trino_smoke_test.py::TrinoSmokeTest.test_trino_smoke@{"cloud_storage_type":1}   # trino
+    - tests/compatibility/kafka_streams_test.py::KafkaStreamsSessionWindow.test_kafka_streams   # kafka-streams-examples
+    - tests/cluster_linking_schema_registry_sync_test.py::ConfluentSchemaRegistrySyncE2ETest.test_schema_registry_api_sync_context_remap   # confluent-schema-registry
+    - tests/data_migrations_api_test.py::DataMigrationsApiTest.test_creating_and_listing_migrations   # rust, rp-storage-tool
+    - tests/flink_basic_test.py::FlinkBasicTests.test_basic_workload   # flink
+    - tests/redpanda_oauth_proxy_test.py::OIDCProxyRejectsPlaintextOriginTest.test_rejects_plaintext_origin   # keycloak, mitmproxy
+    - tests/services_self_test.py::OpenBenchmarkSmokeSelfTest.test_smoke_omb_configuration   # omb
+    - tests/schema_registry_test.py::SchemaRegistryTest.test_serde_client@{"client_type":3,"protocol":2}   # protobuf, golang-test-clients

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -98,6 +98,39 @@ class OpenBenchmarkSelfTest(RedpandaTest):
         benchmark.check_succeed(validate_metrics=self.redpanda.dedicated_nodes)
 
 
+class OpenBenchmarkSmokeSelfTest(RedpandaTest):
+    """Cheap variant of OpenBenchmarkSelfTest for the CDT smoke suite.
+
+    Same goal (prove the OpenMessagingBenchmark service still works), but
+    sized down: one broker at RF=1, the minimum two OMB workers, and a one
+    minute workload with no warmup phase. OMB requires more than one worker
+    because it splits them into producer and consumer sets, so two is the
+    floor here.
+    """
+
+    BENCHMARK_WAIT_TIME_MIN = 5
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, num_brokers=1, **kwargs)
+
+    @skip_debug_mode  # Sends meaningful traffic, and not intended to test Redpanda
+    @cluster(num_nodes=4)
+    def test_smoke_omb_configuration(self) -> None:
+        benchmark = OpenMessagingBenchmark(
+            self.test_context,
+            self.redpanda,
+            "SMOKE_DRIVER_RF1",
+            "SMOKE_WORKLOAD",
+            num_workers=2,
+        )
+        benchmark.start()
+        benchmark_time_min = (
+            benchmark.benchmark_time_mins() + self.BENCHMARK_WAIT_TIME_MIN
+        )
+        benchmark.wait(timeout_sec=benchmark_time_min * 60)
+        benchmark.check_succeed(validate_metrics=self.redpanda.dedicated_nodes)
+
+
 class ProducerSwarmSelfTest(RedpandaTest):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, num_brokers=3, **kwargs)


### PR DESCRIPTION
## What this is

The CDT jobs which gate vtools PRs run `ducktape --sample 3`: a random sample of
three tests out of the full nightly suite. That is a poor fit for what those jobs
are supposed to prove, which is that a change to the ducktape test image, the rig
or `duck.py` still produces a working cluster and a working harness.

Measured on `test_suite_gcp_temporary.yml`, the pool is 3423 test cases with this
node count distribution:

```
{1:352, 2:73, 3:1285, 4:750, 5:334, 6:292, 7:262, 8:18, 9:18, 10:9, 11:12, 12:4, 13:6}
```

Two problems follow. Three cases drawn at random from that mostly land on small
tests which touch very little of the image, so a broken dependency usually goes
unnoticed. And the sample is drawn before the cluster capacity check
(`ducktape/command_line/main.py:152`), so drawing one of the 6 cases which need
more than 12 nodes fails the job outright with no retry. That is exactly what hit
redpanda-data/vtools#4424, at odds of about 1 in 190 runs.

This PR adds the suite. It does not wire anything up to it yet.

## The suite

One cheap test per dependency installed into the test image by
`vtools qa/image/packer/install-deps.sh`, which runs the scripts in
`tests/docker/ducktape-deps/`. Each entry carries a comment naming the script it
covers.

Tests were picked by cost, defined as runtime times nodes allocated, attributing
dependencies per test *method* (per file is far too coarse: a shared file makes a
0 node kubectl test look like it covers omb). Candidates with a suspiciously low
cost were read, which rejected two early-exit no-ops that only look cheap:
`partition_balancer_test.test_nodes_with_reclaimable_space` needs the
`use_xfs_partitions` global, and `SIPartitionMovementTest.test_cross_shard` with
`num_to_upgrade=2` skips on mixed versions.

Measured on CDT, `cdt-aws-nightly-arm64` with 12 nodes: **28 of 28 passed in 326s
of ducktape time** (15.3 min of job wall clock, the rest being provisioning) at
3689 node-seconds. See the run linked below.

## The OMB change

The OMB self test alone was 1118 node-seconds of that, 30% of the suite and more
than triple the next test. All of it is structural rather than workload: the
existing test holds 6 nodes for 2.5 minutes to move traffic at one message per
second, and `usage_stats` from a nightly confirms it, 4.6MB written across 633
batches.

So this adds a smaller variant: one broker at RF=1, four nodes, a one minute
workload with no warm-up. The consumer is kept, so end to end latency is still
measured (2.9ms p50 locally, against a 30ms threshold) and the existing validator
still applies unchanged.

Getting warm-up to zero needed a change to `openmessaging_benchmark.py`, in its
own commit because it affects every OMB test. `start()` waited for OMB's warm-up
banner to detect startup, so a zero warm-up workload would have hung; it now waits
for a pattern matching either phase banner. Verified both ways locally: the new
test passes at 4 nodes in 94s, and the original still passes at 6 nodes in 158s
with startup still detected on the warm-up banner, 60s before the benchmark one.
That is 61% off, measured in one environment.

## Not covered

The `llvm-symbolizer` shim installed by `tool-pkgs` is only ever invoked by the
ASAN or UBSAN runtime inside an instrumented redpanda. Those self tests are gated
on `BUILD_TYPE` being debug or sanitizer, which CDT never sets, so they are
ignored on every CDT run. Coverage for that path has to come from the docker
ducktape runs, which do build sanitized. Deliberately out of scope here.

`/opt/franz-go`, built by the `franz-bench` dep, has no test in the GCP suite at
all: its only user is `scale_tests/franzgo_bench.py`, which that suite does not
include. Left as is.

## Test plan

- CDT: https://buildkite.com/redpanda/redpanda/builds/88865, 28/28 passed, 326s
  of ducktape time. That run predates this suite file: the tests were passed as
  command line IDs and it measured the original 6 node OMB test, not the smaller
  one added here.
- Local `tools/dt`, release: new OMB test passes, 94s at 4 nodes
- Local `tools/dt`, release: original OMB test still passes, 158s at 6 nodes,
  confirming the shared marker change does not regress it
- `task rp:type-check` clean at `standard` on all touched python files

Refs CORE-17089

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none