### PR TITLE
DNM: microbench seastar urgent value/coroutine returns

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -355,7 +355,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "1TtbJjp+c4IAXmHLvNQGubKvnNxXhajyYN+pRWAe8ZY=",
+        "bzlTransitiveDigest": "WN11PflM9lC9dJ/XFdLhFf4sYyjUvPCm85SxKoJxxJ8=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools",
@@ -521,9 +521,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "5918f72ec59c159a8d2fe36870e7d30c6e61426fde766d7dd6853fa7f9871f7f",
-              "strip_prefix": "seastar-a6ac2ff6190a4a9dce5059991355703e1073d11f",
-              "url": "https://github.com/redpanda-data/seastar/archive/a6ac2ff6190a4a9dce5059991355703e1073d11f.tar.gz"
+              "sha256": "45f4836371412dbdfa298df5f41f8544591f778af7ab3a3827dcf5572bc05435",
+              "strip_prefix": "seastar-2e6c9a15a600118f3bea56b61f93dafb5e703cb8",
+              "url": "https://github.com/travisdowns/seastar/archive/2e6c9a15a600118f3bea56b61f93dafb5e703cb8.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -159,9 +159,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "5918f72ec59c159a8d2fe36870e7d30c6e61426fde766d7dd6853fa7f9871f7f",
-        strip_prefix = "seastar-a6ac2ff6190a4a9dce5059991355703e1073d11f",
-        url = "https://github.com/redpanda-data/seastar/archive/a6ac2ff6190a4a9dce5059991355703e1073d11f.tar.gz",
+        sha256 = "45f4836371412dbdfa298df5f41f8544591f778af7ab3a3827dcf5572bc05435",
+        strip_prefix = "seastar-2e6c9a15a600118f3bea56b61f93dafb5e703cb8",
+        url = "https://github.com/travisdowns/seastar/archive/2e6c9a15a600118f3bea56b61f93dafb5e703cb8.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
**Do not merge.** This exists only to get a `/microbench` comparison against the baseline.

Pins seastar at [travisdowns/seastar@2e6c9a1](https://github.com/travisdowns/seastar/commit/2e6c9a15a600118f3bea56b61f93dafb5e703cb8) (branch `td-urgent-sched`, cut from `v26.3.x`), which adds `set_value_urgent()` and uses it from:

- the value and void branches of `futurize<T>::satisfy_with_result_of()`
- `coroutine_traits_base<T>::promise_type::return_value()` / `return_void()`

Today only the third branch of `satisfy_with_result_of()` - the one where the continuation returns an already-ready future - resolves the next promise urgently, via `forward_to()` -> `set_urgent_state()`, which inserts the waiting task at the *front* of the reactor's task queue. The value and void branches call `set_value()`, which appends it to the *back*, behind everything queued while the chain was running. Coroutines always take the appending path, since `return_value()`/`return_void()` go through `set_value()`; with `final_suspend()` being `suspend_never`, each level of a nested `co_await` chain resumes its caller from its own tail-inserted task.

Note this changes the order in which queued tasks run. Seastar's `futures_test` and `coroutines_test` pass in dev, release and sanitize modes, and both files gain a test that asserts the new ordering.

The point of the microbench run is that the change is otherwise unmeasured.