### PR TITLE
datalake/iceberg: parallelize various operations

### DIFF
--- a/src/v/datalake/partitioning_writer.cc
+++ b/src/v/datalake/partitioning_writer.cc
@@ -107,47 +107,47 @@ ss::future<
 partitioning_writer::finish() && {
     chunked_vector<partitioned_file> files;
     auto first_error = writer_error::ok;
-    // TODO: parallelize me!
-    for (auto& [pk, writer] : writers_) {
-        auto file_res = co_await writer->finish();
-        if (file_res.has_error()) {
-            auto is_shutdown_error = file_res.error()
-                                     == writer_error::shutting_down;
-            vlogl(
-              datalake_log,
-              is_shutdown_error ? ss::log_level::debug : ss::log_level::error,
-              "Failed to finish writer: {}",
-              file_res.error());
-            if (first_error == writer_error::ok) {
-                first_error = file_res.error();
-            }
-            // Even on error, move on so that we can close all the writers.
-            continue;
-        }
-        auto partition_key_path_res = partition_key_to_path(spec_, pk);
-        if (partition_key_path_res.has_error()) {
-            vlog(
-              datalake_log.error,
-              "Failed to convert partition key to remote path - {}",
-              partition_key_path_res.error().what());
-            continue;
-        }
+    co_await ss::max_concurrent_for_each(
+      writers_, 10, [&](auto& entry) -> ss::future<> {
+          auto& [pk, writer] = entry;
+          auto file_res = co_await writer->finish();
+          if (file_res.has_error()) {
+              auto is_shutdown_error = file_res.error()
+                                       == writer_error::shutting_down;
+              vlogl(
+                datalake_log,
+                is_shutdown_error ? ss::log_level::debug : ss::log_level::error,
+                "Failed to finish writer: {}",
+                file_res.error());
+              if (first_error == writer_error::ok) {
+                  first_error = file_res.error();
+              }
+              co_return;
+          }
+          auto partition_key_path_res = partition_key_to_path(spec_, pk);
+          if (partition_key_path_res.has_error()) {
+              vlog(
+                datalake_log.error,
+                "Failed to convert partition key to remote path - {}",
+                partition_key_path_res.error().what());
+              co_return;
+          }
 
-        vlog(
-          datalake_log.trace,
-          "writer finished: file_bytes={}, file_path={}",
-          file_res.value().size_bytes,
-          file_res.value().path());
+          vlog(
+            datalake_log.trace,
+            "writer finished: file_bytes={}, file_path={}",
+            file_res.value().size_bytes,
+            file_res.value().path());
 
-        files.push_back(
-          partitioned_file{
-            .local_file = std::move(file_res.value()),
-            .data_location = remote_prefix_,
-            .schema_id = schema_id_,
-            .partition_spec_id = spec_.spec_id,
-            .partition_key = std::move(pk),
-            .partition_key_path = std::move(partition_key_path_res.value())});
-    }
+          files.push_back(
+            partitioned_file{
+              .local_file = std::move(file_res.value()),
+              .data_location = remote_prefix_,
+              .schema_id = schema_id_,
+              .partition_spec_id = spec_.spec_id,
+              .partition_key = std::move(pk),
+              .partition_key_path = std::move(partition_key_path_res.value())});
+      });
 
     vlog(
       datalake_log.trace,

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -500,6 +500,7 @@ redpanda_cc_library(
         ":snapshot",
         ":table_requirement",
         "//src/v/random:generators",
+        "@seastar",
     ],
     deps = [
         ":action",

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -20,6 +20,8 @@
 #include "iceberg/values_bytes.h"
 #include "random/generators.h"
 
+#include <seastar/core/loop.hh>
+
 #include <iterator>
 #include <limits>
 
@@ -494,14 +496,46 @@ merge_append_action::merge_mfiles(
     size_t existing_rows = 0;
     size_t existing_files = 0;
     auto min_seq_num = ctx.seq_num;
-    for (const auto& mfile : to_merge) {
-        // Download the manifest file and collect the entries into the merged
-        // container.
-        auto mfile_res = co_await io_.download_manifest(mfile.manifest_path);
-        if (mfile_res.has_error()) {
-            co_return to_action_errc(mfile_res.error());
-        }
-        auto m = std::move(mfile_res).value();
+
+    // Download manifests in parallel, bounded to avoid monopolizing the
+    // shared cloud storage connection pool.
+    static constexpr size_t max_concurrent_manifest_downloads = 8;
+    struct manifest_download {
+        manifest m;
+        sequence_number seq_num;
+    };
+    chunked_vector<manifest_download> downloaded;
+    downloaded.reserve(to_merge.size());
+    std::optional<action::errc> dl_error;
+    co_await ss::max_concurrent_for_each(
+      to_merge,
+      max_concurrent_manifest_downloads,
+      [&](this auto, const manifest_file& mfile) -> ss::future<> {
+          if (dl_error) {
+              co_return;
+          }
+          auto res = co_await io_.download_manifest(mfile.manifest_path);
+          if (res.has_error()) {
+              dl_error = to_action_errc(res.error());
+              co_return;
+          }
+          downloaded.push_back({
+            .m = std::move(res).value(),
+            .seq_num = mfile.seq_number,
+          });
+      });
+    if (dl_error) {
+        co_return *dl_error;
+    }
+    vassert(
+      downloaded.size() == to_merge.size(),
+      "Expected {} downloaded manifests but got {}",
+      to_merge.size(),
+      downloaded.size());
+
+    // Process downloaded manifests serially.
+    for (auto& dl : downloaded) {
+        auto& m = dl.m;
         max_schema_id = std::max(max_schema_id, m.metadata.schema.schema_id);
         existing_files += m.entries.size();
         for (auto& e : m.entries) {
@@ -521,10 +555,9 @@ merge_append_action::merge_mfiles(
             // These entries refer to files committed prior to this action.
             if (e.status == manifest_entry_status::added) {
                 e.status = manifest_entry_status::existing;
-                e.sequence_number = e.sequence_number.value_or(
-                  mfile.seq_number);
+                e.sequence_number = e.sequence_number.value_or(dl.seq_num);
                 e.file_sequence_number = e.file_sequence_number.value_or(
-                  file_sequence_number{mfile.seq_number()});
+                  file_sequence_number{dl.seq_num()});
             }
             if (e.sequence_number.has_value()) {
                 min_seq_num = std::min(min_seq_num, e.sequence_number.value());

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -688,21 +688,44 @@ merge_append_action::pack_mlist_and_new_data(
           merged_bins.end(),
           std::back_inserter(new_mfiles));
 
-        // Merge the rest of the bins.
-        for (size_t i = 1; i < binned_mfiles.size(); i++) {
-            auto& bin = binned_mfiles[i];
-            if (bin.size() == 1) {
-                // The bin has only a single manifest so there's nothing to do,
-                // just add it as is.
-                new_mfiles.emplace_back(std::move(bin[0]));
-                continue;
-            }
-            auto merged_bin_res = co_await merge_mfiles(
-              std::move(bin), {}, std::nullopt, *pspec, ctx);
-            if (merged_bin_res.has_error()) {
-                co_return merged_bin_res.error();
-            }
-            new_mfiles.emplace_back(std::move(merged_bin_res.value()));
+        // Merge the rest of the bins in parallel. Each bin is an
+        // independent set of manifests that can be merged concurrently.
+        // Results are collected in a parallel vector to preserve bin order.
+        static constexpr size_t max_concurrent_bin_merges = 8;
+        auto remaining_bins = binned_mfiles.size() - 1;
+        chunked_vector<std::optional<manifest_file>> merged_results;
+        merged_results.reserve(remaining_bins);
+        for (size_t i = 0; i < remaining_bins; ++i) {
+            merged_results.emplace_back(std::nullopt);
+        }
+        std::optional<action::errc> bin_error;
+        auto indices = std::views::iota(size_t{0}, remaining_bins);
+        co_await ss::max_concurrent_for_each(
+          indices.begin(),
+          indices.end(),
+          max_concurrent_bin_merges,
+          [&](this auto, size_t i) -> ss::future<> {
+              auto& bin = binned_mfiles[i + 1];
+              if (bin.size() == 1) {
+                  merged_results[i] = std::move(bin[0]);
+                  co_return;
+              }
+              if (bin_error) {
+                  co_return;
+              }
+              auto merged_bin_res = co_await merge_mfiles(
+                std::move(bin), {}, std::nullopt, *pspec, ctx);
+              if (merged_bin_res.has_error()) {
+                  bin_error = merged_bin_res.error();
+                  co_return;
+              }
+              merged_results[i] = std::move(merged_bin_res.value());
+          });
+        if (bin_error) {
+            co_return *bin_error;
+        }
+        for (auto& mf : merged_results) {
+            new_mfiles.emplace_back(std::move(*mf));
         }
     }
     co_return new_mfiles;

--- a/src/v/iceberg/merge_append_action.h
+++ b/src/v/iceberg/merge_append_action.h
@@ -63,7 +63,6 @@ struct field_summary_val {
 // manifests. This is left to the caller, if desired.
 //
 // TODO: doesn't clean up any wasted (e.g. on error) manifest files.
-// TODO: shouldn't be too difficult to parallelize IO.
 class merge_append_action : public action {
 public:
     static constexpr size_t default_min_to_merge_new_files = 100;


### PR DESCRIPTION
Parallelize various embarrassingly parallel operations

1. Manifest downloads during merge
2. Parquet writer finish (including upload)
3. Manifest bin merging

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* The Iceberg subsystem now does some S3 operations in parallel, which should hide some latency of uploads and downloads.


