### PR TITLE
[v26.1.x] [CORE-16972] pandaproxy/rest: return table identity for pre-translation iceberg topics

### DIFF
--- a/src/v/pandaproxy/rest/iceberg_handlers.cc
+++ b/src/v/pandaproxy/rest/iceberg_handlers.cc
@@ -121,13 +121,15 @@ get_translation_state(proxy::server::request_t rq, proxy::server::reply_t rp) {
 
     auto& topic_table = rq.service().topic_table();
 
-    // A requested topic the coordinator doesn't track, but which exists with
-    // Iceberg disabled, is reported as disabled below instead of being omitted.
-    // Enabled-but-untracked topics are excluded: they are still initializing
-    // and will appear via the coordinator with full table state once
-    // registered; surfacing them here without a table identity would be
-    // misleading.
+    // Topics the coordinator doesn't track are classified by their Iceberg
+    // mode so the response always includes an entry for every requested topic
+    // that exists:
+    //  - disabled → status=DISABLED, no table identity
+    //  - enabled  → status=ENABLED with namespace/table derived from config
+    //               (same table_id_provider used once the coordinator tracks
+    //               the topic), but no partition offsets or snapshot id yet
     chunked_vector<model::topic> disabled_topics;
+    chunked_vector<model::topic> enabled_untracked_topics;
     for (const auto& topic_name : req.get_topics_filter()) {
         model::topic topic{topic_name};
         if (topic_states.contains(topic)) {
@@ -135,13 +137,16 @@ get_translation_state(proxy::server::request_t rq, proxy::server::reply_t rp) {
         }
         auto tp_md = topic_table.get_topic_metadata_ref(
           model::topic_namespace_view(model::kafka_namespace, topic));
-        if (
-          !tp_md
-          || get_translation_status(tp_md->get().get_configuration())
-               != proto::pandaproxy::translation_status::disabled) {
+        if (!tp_md) {
             continue;
         }
-        disabled_topics.push_back(std::move(topic));
+        if (
+          get_translation_status(tp_md->get().get_configuration())
+          == proto::pandaproxy::translation_status::disabled) {
+            disabled_topics.push_back(std::move(topic));
+        } else {
+            enabled_untracked_topics.push_back(std::move(topic));
+        }
     }
 
     // Filter out topics the user is not authorized to describe.
@@ -171,6 +176,10 @@ get_translation_state(proxy::server::request_t rq, proxy::server::reply_t rp) {
           disabled_topics,
           [&](const auto& topic) { return !is_authorized(topic); });
         disabled_topics.erase_to_end(unauthorized.begin());
+        auto unauth_enabled = std::ranges::remove_if(
+          enabled_untracked_topics,
+          [&](const auto& topic) { return !is_authorized(topic); });
+        enabled_untracked_topics.erase_to_end(unauth_enabled.begin());
     }
 
     proto::pandaproxy::get_translation_state_response resp;
@@ -242,6 +251,18 @@ get_translation_state(proxy::server::request_t rq, proxy::server::reply_t rp) {
         proto::pandaproxy::topic_state pb_state;
         pb_state.set_translation_status(
           proto::pandaproxy::translation_status::disabled);
+        pb_topic_states.emplace(topic(), std::move(pb_state));
+    }
+
+    for (const auto& topic : enabled_untracked_topics) {
+        proto::pandaproxy::topic_state pb_state;
+        pb_state.set_translation_status(
+          proto::pandaproxy::translation_status::enabled);
+        auto table_id = datalake::table_id_provider::table_id(topic);
+        pb_state.set_table_name(std::move(table_id.table));
+        pb_state.set_namespace_name(std::move(table_id.ns));
+        pb_state.set_dlq_table_name(
+          datalake::table_id_provider::dlq_table_id(topic).table);
         pb_topic_states.emplace(topic(), std::move(pb_state));
     }
     resp.set_topic_states(std::move(pb_topic_states));

--- a/tests/rptest/tests/datalake/iceberg_translation_state_test.py
+++ b/tests/rptest/tests/datalake/iceberg_translation_state_test.py
@@ -114,26 +114,57 @@ class IcebergTranslationStateTest(RedpandaTest):
             dl.create_iceberg_enabled_topic(topic_name, partitions=3)
             rpk.create_topic(non_iceberg_topic)
 
-            for i in range(10):
-                rpk.produce(topic_name, f"key-{i}", f"value-{i}")
-
-            # Wait for translation state to become available
-            def translation_state_ready():
+            # Before any data is produced, the Iceberg-enabled topic should
+            # already appear with its table identity (namespace, table, dlq)
+            # and status=ENABLED, but with no partition offsets or snapshot.
+            def pre_translation_state_ready():
                 result = self._try_get_translation_state(topics_filter=[topic_name])
                 return result is not None and topic_name in result.topic_states
 
             wait_until(
-                translation_state_ready,
+                pre_translation_state_ready,
                 timeout_sec=30,
                 backoff_sec=2,
-                err_msg="Translation state not available for topic",
+                err_msg="Pre-translation state not available for topic",
             )
 
             result = self._get_translation_state(topics_filter=[topic_name])
-            assert topic_name in result.topic_states, (
-                f"Topic {topic_name} not in response"
+            pre_state = result.topic_states[topic_name]
+            assert (
+                pre_state.translation_status == iceberg_pb2.TRANSLATION_STATUS_ENABLED
+            ), (
+                f"Expected ENABLED before translation, got {pre_state.translation_status}"
+            )
+            assert list(pre_state.namespace_name) == ["redpanda"], (
+                f"Expected namespace ['redpanda'], got {list(pre_state.namespace_name)}"
+            )
+            assert pre_state.table_name == topic_name, (
+                f"Expected table name '{topic_name}', got '{pre_state.table_name}'"
+            )
+            assert pre_state.dlq_table_name == f"{topic_name}~dlq", (
+                f"Expected DLQ table name '{topic_name}~dlq', got '{pre_state.dlq_table_name}'"
             )
 
+            for i in range(10):
+                rpk.produce(topic_name, f"key-{i}", f"value-{i}")
+
+            # After data is produced and translated, partition states appear.
+            def translation_complete():
+                result = self._try_get_translation_state(topics_filter=[topic_name])
+                return (
+                    result is not None
+                    and topic_name in result.topic_states
+                    and len(result.topic_states[topic_name].partition_states) == 3
+                )
+
+            wait_until(
+                translation_complete,
+                timeout_sec=30,
+                backoff_sec=2,
+                err_msg="Translation state partitions not populated",
+            )
+
+            result = self._get_translation_state(topics_filter=[topic_name])
             state = result.topic_states[topic_name]
             assert state.translation_status == iceberg_pb2.TRANSLATION_STATUS_ENABLED, (
                 f"Unexpected status: {state.translation_status}"


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31600
