### PR TITLE
iceberg/datalake: collect NaN stats

### DIFF
--- a/src/v/datalake/base_types.h
+++ b/src/v/datalake/base_types.h
@@ -33,7 +33,7 @@ using remote_path = named_type<std::filesystem::path, struct remote_path_tag>;
 /// (identical to Parquet PLAIN encoding for all supported types).
 struct per_column_stats
   : serde::
-      envelope<per_column_stats, serde::version<0>, serde::compat_version<0>> {
+      envelope<per_column_stats, serde::version<1>, serde::compat_version<0>> {
     auto serde_fields() {
         return std::tie(
           field_id,
@@ -41,7 +41,8 @@ struct per_column_stats
           upper_bound,
           null_value_count,
           value_count,
-          column_size_bytes);
+          column_size_bytes,
+          nan_value_count);
     }
 
     int32_t field_id = -1;
@@ -50,6 +51,7 @@ struct per_column_stats
     int64_t null_value_count = 0;
     int64_t value_count = 0;
     int64_t column_size_bytes = 0;
+    int64_t nan_value_count = 0;
 
     friend bool
     operator==(const per_column_stats&, const per_column_stats&) = default;

--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -298,7 +298,8 @@ public:
                     chunked_hash_map<iceberg::nested_field::id_t, iobuf>
                       lower_bounds, upper_bounds;
                     chunked_hash_map<iceberg::nested_field::id_t, int64_t>
-                      null_value_counts, value_counts, column_sizes;
+                      null_value_counts, nan_value_counts, value_counts,
+                      column_sizes;
                     for (const auto& cs : f.column_stats) {
                         auto fid = iceberg::nested_field::id_t{cs.field_id};
                         if (cs.lower_bound) {
@@ -308,6 +309,7 @@ public:
                             upper_bounds[fid] = bytes_to_iobuf(*cs.upper_bound);
                         }
                         null_value_counts[fid] = cs.null_value_count;
+                        nan_value_counts[fid] = cs.nan_value_count;
                         value_counts[fid] = cs.value_count;
                         column_sizes[fid] = cs.column_size_bytes;
                     }
@@ -318,6 +320,7 @@ public:
                         file.upper_bounds = std::move(upper_bounds);
                     }
                     file.null_value_counts = std::move(null_value_counts);
+                    file.nan_value_counts = std::move(nan_value_counts);
                     file.value_counts = std::move(value_counts);
                     file.column_sizes = std::move(column_sizes);
                 }

--- a/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
@@ -824,6 +824,7 @@ TEST_F(FileCommitterTest, TestColumnStatsInManifest) {
     cs.lower_bound = bytes::from_string("aardvark");
     cs.upper_bound = bytes::from_string("zebra");
     cs.null_value_count = 5;
+    cs.nan_value_count = 3;
     cs.value_count = 100;
     cs.column_size_bytes = 4096;
 
@@ -898,6 +899,10 @@ TEST_F(FileCommitterTest, TestColumnStatsInManifest) {
 
     ASSERT_NE(ifile.column_sizes->find(fid), ifile.column_sizes->end());
     EXPECT_EQ(4096, ifile.column_sizes->at(fid));
+
+    ASSERT_TRUE(ifile.nan_value_counts.has_value());
+    ASSERT_NE(ifile.nan_value_counts->find(fid), ifile.nan_value_counts->end());
+    EXPECT_EQ(3, ifile.nan_value_counts->at(fid));
 }
 
 // With a byte-based commit limit, files carrying large column stats are split

--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -132,6 +132,7 @@ ss::future<writer_error> serde_parquet_writer::finish() {
         if (cs.bounds.max) {
             ps.upper_bound = iobuf_to_bytes(cs.bounds.max->value);
         }
+        ps.nan_value_count = cs.nan_value_count;
         _column_stats.push_back(std::move(ps));
     }
     _buffered_bytes = _flushed_bytes = 0;

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -20,6 +20,7 @@
 #include "iceberg/values_bytes.h"
 #include "random/generators.h"
 
+#include <cmath>
 #include <iterator>
 #include <limits>
 
@@ -105,9 +106,23 @@ void update_partition_summaries(
             summaries[i].contains_null = true;
             continue;
         }
-        // TODO: contains_nan
         const auto& file_prim_val = std::get<primitive_value>(
           file_val_field.value());
+        bool is_nan = std::visit(
+          [](const auto& v) -> bool {
+              using T = std::decay_t<decltype(v)>;
+              if constexpr (
+                std::is_same_v<T, float_value>
+                || std::is_same_v<T, double_value>) {
+                  return std::isnan(v.val);
+              }
+              return false;
+          },
+          file_prim_val);
+        if (is_nan) {
+            summaries[i].contains_nan = true;
+            continue;
+        }
         if (!summaries[i].lower_bound.has_value()) {
             summaries[i].lower_bound = make_copy(file_prim_val);
         } else {

--- a/src/v/iceberg/tests/merge_append_action_test.cc
+++ b/src/v/iceberg/tests/merge_append_action_test.cc
@@ -22,6 +22,8 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 using namespace iceberg;
 using namespace std::chrono_literals;
 
@@ -478,6 +480,182 @@ TEST_F(MergeAppendActionTest, TestPartitionSummaries) {
       latest_partitions[0].lower_bound, value_to_bytes(int_value{base_pk}));
     ASSERT_EQ(
       latest_partitions[0].upper_bound, value_to_bytes(int_value{last_pk}));
+}
+
+TEST_F(MergeAppendActionTest, TestPartitionSummaryContainsNan) {
+    // Create a table with a float partition field so we can test NaN handling.
+    auto create_float_partitioned_table = [this]() {
+        struct_type schema_struct;
+        schema_struct.fields.emplace_back(
+          nested_field::create(1, "id", field_required::yes, int_type{}));
+        schema_struct.fields.emplace_back(
+          nested_field::create(2, "val", field_required::no, float_type{}));
+        auto s = schema{
+          .schema_struct = std::move(schema_struct),
+          .schema_id = schema::id_t{0},
+          .identifier_field_ids = {},
+        };
+        chunked_vector<schema> schemas;
+        schemas.emplace_back(s.copy());
+        chunked_vector<partition_spec> pspecs;
+        pspecs.emplace_back(partition_spec{
+          .spec_id = partition_spec::id_t{0},
+          .fields = {
+            partition_field{
+              .source_id = nested_field::id_t{2},
+              .field_id = partition_field::id_t{1000},
+              .name = "val",
+              .transform = identity_transform{},
+            },
+          },
+        });
+        return table_metadata{
+          .format_version = format_version::v2,
+          .table_uuid = uuid_t::create(),
+          .location = uri(fmt::format("s3://{}/foo/bar", bucket_name())),
+          .last_sequence_number = sequence_number{0},
+          .last_updated_ms = model::timestamp::now(),
+          .last_column_id = s.highest_field_id().value(),
+          .schemas = std::move(schemas),
+          .current_schema_id = schema::id_t{0},
+          .partition_specs = std::move(pspecs),
+          .default_spec_id = partition_spec::id_t{0},
+          .last_partition_id = partition_field::id_t{-1},
+        };
+    };
+
+    // Append files with only normal float values.
+    {
+        transaction tx(create_float_partitioned_table());
+        auto files = create_data_files(
+          tx.table(), "normal", 1, 10, float_value{1.5f});
+        auto res = tx.merge_append(io, std::move(files)).get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+
+        auto mlist_path = tx.table().snapshots->back().manifest_list_path;
+        auto mlist = io.download_manifest_list(mlist_path).get();
+        ASSERT_TRUE(mlist.has_value());
+        const auto& partitions = mlist.value().files[0].partitions;
+        ASSERT_EQ(1, partitions.size());
+        ASSERT_FALSE(partitions[0].contains_null);
+        EXPECT_FALSE(partitions[0].contains_nan.value_or(false));
+        EXPECT_TRUE(partitions[0].lower_bound.has_value());
+        EXPECT_TRUE(partitions[0].upper_bound.has_value());
+    }
+
+    // Append files with only NaN partition values.
+    {
+        transaction tx(create_float_partitioned_table());
+        auto nan = std::numeric_limits<float>::quiet_NaN();
+        auto files = create_data_files(
+          tx.table(), "nan_only", 1, 10, float_value{nan});
+        auto res = tx.merge_append(io, std::move(files)).get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+
+        auto mlist_path = tx.table().snapshots->back().manifest_list_path;
+        auto mlist = io.download_manifest_list(mlist_path).get();
+        ASSERT_TRUE(mlist.has_value());
+        const auto& partitions = mlist.value().files[0].partitions;
+        ASSERT_EQ(1, partitions.size());
+        ASSERT_FALSE(partitions[0].contains_null);
+        ASSERT_TRUE(partitions[0].contains_nan.has_value());
+        EXPECT_TRUE(partitions[0].contains_nan.value());
+        // NaN should not contribute to bounds.
+        EXPECT_FALSE(partitions[0].lower_bound.has_value());
+        EXPECT_FALSE(partitions[0].upper_bound.has_value());
+    }
+
+    // Append files with a mix of normal and NaN values.
+    {
+        transaction tx(create_float_partitioned_table());
+        auto nan = std::numeric_limits<float>::quiet_NaN();
+        auto normal_files = create_data_files(
+          tx.table(), "mixed_normal", 1, 10, float_value{3.0f});
+        auto nan_files = create_data_files(
+          tx.table(), "mixed_nan", 1, 10, float_value{nan});
+        std::move(
+          nan_files.begin(), nan_files.end(), std::back_inserter(normal_files));
+        auto res = tx.merge_append(io, std::move(normal_files)).get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+
+        auto mlist_path = tx.table().snapshots->back().manifest_list_path;
+        auto mlist = io.download_manifest_list(mlist_path).get();
+        ASSERT_TRUE(mlist.has_value());
+        const auto& partitions = mlist.value().files[0].partitions;
+        ASSERT_EQ(1, partitions.size());
+        ASSERT_FALSE(partitions[0].contains_null);
+        ASSERT_TRUE(partitions[0].contains_nan.has_value());
+        EXPECT_TRUE(partitions[0].contains_nan.value());
+        // Bounds should reflect only non-NaN values.
+        EXPECT_TRUE(partitions[0].lower_bound.has_value());
+        EXPECT_TRUE(partitions[0].upper_bound.has_value());
+        auto expected_bytes = value_to_bytes(float_value{3.0f});
+        EXPECT_EQ(partitions[0].lower_bound.value(), expected_bytes);
+        EXPECT_EQ(partitions[0].upper_bound.value(), expected_bytes);
+    }
+
+    // Same tests with double.
+    {
+        // Need a double partition field.
+        struct_type schema_struct;
+        schema_struct.fields.emplace_back(
+          nested_field::create(1, "id", field_required::yes, int_type{}));
+        schema_struct.fields.emplace_back(
+          nested_field::create(2, "val", field_required::no, double_type{}));
+        auto s = schema{
+          .schema_struct = std::move(schema_struct),
+          .schema_id = schema::id_t{0},
+          .identifier_field_ids = {},
+        };
+        chunked_vector<schema> schemas;
+        schemas.emplace_back(s.copy());
+        chunked_vector<partition_spec> pspecs;
+        pspecs.emplace_back(partition_spec{
+          .spec_id = partition_spec::id_t{0},
+          .fields = {
+            partition_field{
+              .source_id = nested_field::id_t{2},
+              .field_id = partition_field::id_t{1000},
+              .name = "val",
+              .transform = identity_transform{},
+            },
+          },
+        });
+        auto table = table_metadata{
+          .format_version = format_version::v2,
+          .table_uuid = uuid_t::create(),
+          .location = uri(fmt::format("s3://{}/foo/bar", bucket_name())),
+          .last_sequence_number = sequence_number{0},
+          .last_updated_ms = model::timestamp::now(),
+          .last_column_id = s.highest_field_id().value(),
+          .schemas = std::move(schemas),
+          .current_schema_id = schema::id_t{0},
+          .partition_specs = std::move(pspecs),
+          .default_spec_id = partition_spec::id_t{0},
+          .last_partition_id = partition_field::id_t{-1},
+        };
+        transaction tx(std::move(table));
+        auto nan = std::numeric_limits<double>::quiet_NaN();
+        auto normal_files = create_data_files(
+          tx.table(), "dbl_normal", 1, 10, double_value{2.5});
+        auto nan_files = create_data_files(
+          tx.table(), "dbl_nan", 1, 10, double_value{nan});
+        std::move(
+          nan_files.begin(), nan_files.end(), std::back_inserter(normal_files));
+        auto res = tx.merge_append(io, std::move(normal_files)).get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+
+        auto mlist_path = tx.table().snapshots->back().manifest_list_path;
+        auto mlist = io.download_manifest_list(mlist_path).get();
+        ASSERT_TRUE(mlist.has_value());
+        const auto& partitions = mlist.value().files[0].partitions;
+        ASSERT_EQ(1, partitions.size());
+        ASSERT_TRUE(partitions[0].contains_nan.has_value());
+        EXPECT_TRUE(partitions[0].contains_nan.value());
+        auto expected_bytes = value_to_bytes(double_value{2.5});
+        EXPECT_EQ(partitions[0].lower_bound.value(), expected_bytes);
+        EXPECT_EQ(partitions[0].upper_bound.value(), expected_bytes);
+    }
 }
 
 TEST_F(MergeAppendActionTest, TestBadMetadata) {

--- a/src/v/serde/parquet/column_stats_collector.h
+++ b/src/v/serde/parquet/column_stats_collector.h
@@ -69,6 +69,7 @@ public:
     void record_value(ref_type v) {
         if constexpr (std::is_floating_point_v<decltype(v.val)>) {
             if (std::isnan(v.val)) {
+                ++_nan_count;
                 return;
             }
         }
@@ -86,6 +87,7 @@ public:
     // Merge another stats collector into this one.
     void merge(column_stats_collector<value_type, comparator>& other) {
         _null_count += other._null_count;
+        _nan_count += other._nan_count;
         if (
           other._min
           && (!_min || comparator(*other._min, *_min) == std::strong_ordering::less)) {
@@ -100,11 +102,13 @@ public:
 
     void reset() {
         _null_count = 0;
+        _nan_count = 0;
         _min = std::nullopt;
         _max = std::nullopt;
     }
 
     int64_t null_count() const { return _null_count; }
+    int64_t nan_count() const { return _nan_count; }
 
     // Byte-array bounds are retained untruncated.
     int64_t memory_usage() const {
@@ -138,6 +142,7 @@ private:
     std::optional<value_type> _min;
     std::optional<value_type> _max;
     int64_t _null_count = 0;
+    int64_t _nan_count = 0;
 };
 
 } // namespace serde::parquet

--- a/src/v/serde/parquet/column_writer.cc
+++ b/src/v/serde/parquet/column_writer.cc
@@ -54,6 +54,7 @@ public:
     virtual ss::future<> next_page() = 0;
     virtual ss::future<flushed_pages> flush_pages() = 0;
     virtual statistics file_column_stats() = 0;
+    virtual int64_t file_nan_count() = 0;
 };
 
 namespace {
@@ -369,6 +370,8 @@ public:
         return build_statistics(_file_stats);
     }
 
+    int64_t file_nan_count() override { return _file_stats.nan_count(); }
+
 private:
     using collector = column_stats_collector<value_type, comparator>;
 
@@ -524,6 +527,8 @@ ss::future<flushed_pages> column_writer::flush_pages() {
 statistics column_writer::file_column_stats() {
     return _impl->file_column_stats();
 }
+
+int64_t column_writer::file_nan_count() { return _impl->file_nan_count(); }
 
 size_t estimated_column_memory() {
     // Empirical: the column writer object, the chunks its containers take on

--- a/src/v/serde/parquet/column_writer.h
+++ b/src/v/serde/parquet/column_writer.h
@@ -104,6 +104,10 @@ public:
     // to this column. Must be called after the final flush_pages().
     statistics file_column_stats();
 
+    // Total NaN count across all row groups. Must be called after the final
+    // flush_pages(). Non-zero only for float/double columns.
+    int64_t file_nan_count();
+
 private:
     std::unique_ptr<impl> _impl;
 };

--- a/src/v/serde/parquet/tests/writer_test.cc
+++ b/src/v/serde/parquet/tests/writer_test.cc
@@ -565,6 +565,64 @@ TEST(ParquetWriter, StatsEdgeFloat64) {
       f64_type{}, {float64_value{lim::lowest()}, float64_value{lim::max()}});
 }
 
+TEST(ParquetWriter, NanValueCountFloat32) {
+    using lim = std::numeric_limits<float>;
+    iobuf file;
+    writer w(
+      {.schema = single_col_schema(f32_type{}), .max_stats_truncate_length = 0},
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+    // Write 2 NaN values and 3 normal values.
+    for (auto v : {lim::quiet_NaN(), 1.0f, lim::signaling_NaN(), 2.0f, 3.0f}) {
+        chunked_vector<group_member> fields;
+        fields.push_back(group_member{float32_value{v}});
+        w.write_row(group_value{std::move(fields)}).get();
+    }
+    w.close().get();
+    auto stats = w.column_file_stats();
+    ASSERT_EQ(1, stats.size());
+    EXPECT_EQ(2, stats[0].nan_value_count);
+    EXPECT_EQ(5, stats[0].value_count);
+}
+
+TEST(ParquetWriter, NanValueCountFloat64) {
+    using lim = std::numeric_limits<double>;
+    iobuf file;
+    writer w(
+      {.schema = single_col_schema(f64_type{}), .max_stats_truncate_length = 0},
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+    // Write 1 NaN, 2 normal values.
+    for (auto v : {lim::quiet_NaN(), 1.0, 2.0}) {
+        chunked_vector<group_member> fields;
+        fields.push_back(group_member{float64_value{v}});
+        w.write_row(group_value{std::move(fields)}).get();
+    }
+    w.close().get();
+    auto stats = w.column_file_stats();
+    ASSERT_EQ(1, stats.size());
+    EXPECT_EQ(1, stats[0].nan_value_count);
+    EXPECT_EQ(3, stats[0].value_count);
+}
+
+TEST(ParquetWriter, NanValueCountIntColumn) {
+    // Non-float columns should always have nan_value_count == 0.
+    iobuf file;
+    writer w(
+      {.schema = single_col_schema(i32_type{}), .max_stats_truncate_length = 0},
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+    for (int i = 0; i < 5; ++i) {
+        chunked_vector<group_member> fields;
+        fields.push_back(group_member{int32_value{i}});
+        w.write_row(group_value{std::move(fields)}).get();
+    }
+    w.close().get();
+    auto stats = w.column_file_stats();
+    ASSERT_EQ(1, stats.size());
+    EXPECT_EQ(0, stats[0].nan_value_count);
+}
+
 TEST(ParquetWriter, StatsEdgeByteArray) {
     // Empty string: min == max == ""
     check_byte_array_stats({""});

--- a/src/v/serde/parquet/writer.cc
+++ b/src/v/serde/parquet/writer.cc
@@ -220,6 +220,7 @@ public:
               .bounds = col.writer.file_column_stats(),
               .value_count = col.file_value_count,
               .column_size_bytes = col.file_column_size_bytes,
+              .nan_value_count = col.writer.file_nan_count(),
             });
         }
         return result;

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -127,6 +127,8 @@ public:
         int64_t value_count = 0;
         /// Total compressed size in bytes across all row groups.
         int64_t column_size_bytes = 0;
+        /// Total number of NaN values across all row groups.
+        int64_t nan_value_count = 0;
     };
     chunked_vector<file_column_stats> column_file_stats();
 


### PR DESCRIPTION
Collect NaN stats on partition keys and data files and propagate them to manifest. This benefits query planners dealing with floating point values.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Improvements

* The Iceberg subsystem now collects NaN statistics and propagates them to Iceberg manifests.

