### PR TITLE
[CORE-16802] - KIP-848: the consumer group type and heartbeat dispatch

### DIFF
--- a/src/v/kafka/protocol/consumer_group_heartbeat.h
+++ b/src/v/kafka/protocol/consumer_group_heartbeat.h
@@ -13,6 +13,7 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/consumer_group_heartbeat_request.h"
 #include "kafka/protocol/schemata/consumer_group_heartbeat_response.h"
+#include "model/fundamental.h"
 
 #include <seastar/core/future.hh>
 
@@ -22,6 +23,9 @@ struct consumer_group_heartbeat_request final {
     using api_type = consumer_group_heartbeat_api;
 
     consumer_group_heartbeat_request_data data;
+
+    // set during request processing after mapping group to ntp
+    model::ntp ntp;
 
     void encode(protocol::encoder& writer, api_version version) {
         data.encode(writer, version);
@@ -40,6 +44,16 @@ struct consumer_group_heartbeat_response final {
     using api_type = consumer_group_heartbeat_api;
 
     consumer_group_heartbeat_response_data data;
+
+    consumer_group_heartbeat_response() = default;
+
+    consumer_group_heartbeat_response(
+      const consumer_group_heartbeat_request& request, error_code error)
+      : data{
+          .error_code = error,
+          .member_id = request.data.member_id,
+          .member_epoch = request.data.member_epoch,
+        } {}
 
     void encode(protocol::encoder& writer, api_version version) {
         data.encode(writer, version);

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -494,6 +494,12 @@ field_name_type_map = {
     ("int32", "ThrottleTimeMs"): ("std::chrono::milliseconds", 0),
     ("int32", "SessionTimeoutMs"): ("std::chrono::milliseconds", None),
     ("int32", "RebalanceTimeoutMs"): ("std::chrono::milliseconds", None),
+    # a named_type over an arithmetic type value-initializes to the type's
+    # minimum, so an epoch with no default in the schema needs one here to
+    # keep the zero an int32 field would have had
+    ("int32", "GroupEpoch"): ("kafka::group_epoch", 0),
+    ("int32", "AssignmentEpoch"): ("kafka::assignment_epoch", 0),
+    ("int32", "MemberEpoch"): ("kafka::member_epoch", 0),
 }
 
 # primitive types

--- a/src/v/kafka/protocol/types.h
+++ b/src/v/kafka/protocol/types.h
@@ -218,6 +218,9 @@ inline constexpr std::string_view group_state_name_completing_rebalance
   = "CompletingRebalance";
 inline constexpr std::string_view group_state_name_stable = "Stable";
 inline constexpr std::string_view group_state_name_dead = "Dead";
+/// Consumer group states. Empty, Stable and Dead are named above and shared.
+inline constexpr std::string_view group_state_name_assigning = "Assigning";
+inline constexpr std::string_view group_state_name_reconciling = "Reconciling";
 
 /// An unknown / missing generation id (Kafka protocol specific)
 inline constexpr generation_id unknown_generation_id(-1);

--- a/src/v/kafka/protocol/types.h
+++ b/src/v/kafka/protocol/types.h
@@ -58,6 +58,16 @@ inline constexpr leader_epoch invalid_leader_epoch(-1);
 /// Kafka group generation identifier.
 using generation_id = named_type<int32_t, struct kafka_generation_id>;
 
+/// A consumer group's epoch, bumped whenever a new assignment is owed.
+using group_epoch = named_type<int32_t, struct kafka_group_epoch>;
+
+/// The group epoch a target assignment was computed at.
+using assignment_epoch = named_type<int32_t, struct kafka_assignment_epoch>;
+
+/// A consumer group member's epoch. Advances toward the group epoch as the
+/// member finishes reconciling its assignment.
+using member_epoch = named_type<int32_t, struct kafka_member_epoch>;
+
 /// Kafka group protocol type.
 using protocol_type = named_type<ss::sstring, struct kafka_protocol_type>;
 

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -159,6 +159,7 @@ redpanda_cc_library(
     srcs = [
         "client_quota_translator.cc",
         "connection_context.cc",
+        "consumer_group.cc",
         "data_migration_group_proxy_impl.cc",
         "fetch_memory_units.cc",
         "fetch_pid_controller.cc",
@@ -218,6 +219,7 @@ redpanda_cc_library(
         "atomic_token_bucket.h",
         "client_quota_translator.h",
         "connection_context.h",
+        "consumer_group.h",
         "coordinator_ntp_mapper.h",
         "data_migration_group_proxy_impl.h",
         "errors.h",

--- a/src/v/kafka/server/consumer_group.cc
+++ b/src/v/kafka/server/consumer_group.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/server/consumer_group.h"
+
+#include <algorithm>
+#include <exception>
+#include <utility>
+
+namespace kafka {
+
+std::string_view to_string_view(consumer_group_state s) {
+    switch (s) {
+    case consumer_group_state::empty:
+        return group_state_name_empty;
+    case consumer_group_state::assigning:
+        return group_state_name_assigning;
+    case consumer_group_state::reconciling:
+        return group_state_name_reconciling;
+    case consumer_group_state::stable:
+        return group_state_name_stable;
+    case consumer_group_state::dead:
+        return group_state_name_dead;
+    }
+    std::terminate();
+}
+
+consumer_group::consumer_group(
+  kafka::group_id id,
+  config::configuration& conf,
+  ss::lw_shared_ptr<ss::rwlock> catchup_lock,
+  std::unique_ptr<offset_writer> writer,
+  model::term_id term,
+  std::unique_ptr<tx_coordinator_client> tx_coordinator,
+  ss::sharded<features::feature_table>& feature_table)
+  : _id(std::move(id))
+  , _offset_store(
+      _id,
+      conf,
+      std::move(catchup_lock),
+      std::move(writer),
+      term,
+      std::move(tx_coordinator),
+      feature_table,
+      [this] { return _removed; }) {}
+
+void consumer_group::upsert_member(consumer_group_member member) {
+    auto id = member.id;
+    _members.insert_or_assign(std::move(id), std::move(member));
+}
+
+consumer_group_state consumer_group::state() const {
+    if (_members.empty()) {
+        return consumer_group_state::empty;
+    }
+    if (_epoch() > _assignment_epoch()) {
+        return consumer_group_state::assigning;
+    }
+    // Reaching the epoch the target was computed at is not enough: a member
+    // whose epoch was bumped still holds partitions it owes back, or waits for
+    // partitions their previous owner has not released, and reports that in its
+    // own state. Its epoch and the assignment epoch are separate types because
+    // assigning one to the other is always a bug, so compare their values.
+    const auto reconciled = [this](const members_map::value_type& m) {
+        return m.second.state == consumer_group_member_state::stable
+               && m.second.epoch() == _assignment_epoch();
+    };
+    return std::all_of(_members.begin(), _members.end(), reconciled)
+             ? consumer_group_state::stable
+             : consumer_group_state::reconciling;
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/consumer_group.h
+++ b/src/v/kafka/server/consumer_group.h
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "base/format_to.h"
+#include "base/seastarx.h"
+#include "config/configuration.h"
+#include "container/chunked_hash_map.h"
+#include "container/chunked_vector.h"
+#include "features/feature_table.h"
+#include "kafka/protocol/types.h"
+#include "kafka/server/group_metadata.h"
+#include "kafka/server/offset_store.h"
+#include "kafka/server/offset_writer.h"
+#include "kafka/server/tx_coordinator_client.h"
+#include "model/fundamental.h"
+
+#include <seastar/core/rwlock.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shared_ptr.hh>
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string_view>
+
+namespace kafka {
+
+/// Partitions grouped by topic, so a topic is named once however many of its
+/// partitions one member holds. Keyed by topic id, as the assignment records
+/// are, so a recreated topic is a different key.
+using member_partitions
+  = chunked_hash_map<model::topic_id, chunked_hash_set<model::partition_id>>;
+
+/// A consumer group's lifecycle label.
+enum class consumer_group_state {
+    /// No members.
+    empty,
+    /// A new assignment is owed: the group epoch is ahead of the assignment
+    /// epoch, so the target is being computed.
+    assigning,
+    /// A target is computed and the members are converging on it.
+    reconciling,
+    /// Every member has reached the assignment epoch.
+    stable,
+    /// Nominal terminal state, for parity with the classic group states.
+    /// Deletion tombstones an empty group instead, so a group is never
+    /// observed in it.
+    dead,
+};
+
+std::string_view to_string_view(consumer_group_state);
+
+inline fmt::iterator format_to(consumer_group_state s, fmt::iterator out) {
+    return fmt::format_to(out, "{}", to_string_view(s));
+}
+
+/// What a member asked for in its heartbeat.
+struct consumer_group_subscription {
+    kafka::client_id client_id;
+    kafka::client_host client_host;
+    std::optional<kafka::group_instance_id> instance_id;
+    std::optional<model::rack_id> rack_id;
+    chunked_vector<model::topic> topics;
+    std::chrono::milliseconds rebalance_timeout{-1};
+    /// The assignor the member asked the server to use, if it named one.
+    std::optional<ss::sstring> assignor;
+};
+
+/// \brief One member of a consumer group.
+///
+/// Carries what the member subscribed to, and how far it has reconciled toward
+/// the group's target assignment. A member owns a partition only once it has
+/// been assigned and the previous owner has released it, so `assigned` and
+/// `pending_revocation` are disjoint.
+struct consumer_group_member {
+    kafka::member_id id;
+    consumer_group_subscription subscription;
+    /// How far this member has reconciled. Advances toward the group epoch, and
+    /// equals the assignment epoch once the member is caught up.
+    kafka::member_epoch epoch{0};
+    /// The epoch to accept if the member never saw the last bump.
+    kafka::member_epoch previous_epoch{0};
+    consumer_group_member_state state{consumer_group_member_state::unknown};
+    member_partitions assigned;
+    member_partitions pending_revocation;
+};
+
+/// \brief A consumer group, as defined by KIP-848.
+///
+/// The sibling of the classic `group`, for members that speak the consumer
+/// rebalance protocol. Two differences shape it:
+///
+/// - assignment is computed by the server, so the group carries a target
+///   assignment and each member's progress toward it rather than the opaque
+///   bytes a client leader produced;
+/// - there is no rebalance barrier. Three epochs stand in for one: the group's,
+///   the one a target was computed at, and each member's. `state()` is derived
+///   from them, so nothing sets it and there is no stop-the-world state.
+///
+/// Committed offsets and EOS live in the composed `offset_store`, which the
+/// classic `group` composes too.
+class consumer_group {
+public:
+    using members_map
+      = chunked_hash_map<kafka::member_id, consumer_group_member>;
+
+    /// Takes the offset writer and the transaction-coordinator client rather
+    /// than a partition, so the caller decides what the group writes through.
+    consumer_group(
+      kafka::group_id id,
+      config::configuration& conf,
+      ss::lw_shared_ptr<ss::rwlock> catchup_lock,
+      std::unique_ptr<offset_writer> writer,
+      model::term_id term,
+      std::unique_ptr<tx_coordinator_client> tx_coordinator,
+      ss::sharded<features::feature_table>& feature_table);
+
+    consumer_group(const consumer_group&) = delete;
+    consumer_group& operator=(const consumer_group&) = delete;
+    consumer_group(consumer_group&&) = delete;
+    consumer_group& operator=(consumer_group&&) = delete;
+    ~consumer_group() noexcept = default;
+
+    const kafka::group_id& id() const { return _id; }
+
+    /// Bumped whenever a new assignment is owed.
+    kafka::group_epoch epoch() const { return _epoch; }
+
+    /// The group epoch the current target assignment was computed at. Behind
+    /// the group epoch while a new target is owed.
+    kafka::assignment_epoch assignment_epoch() const {
+        return _assignment_epoch;
+    }
+
+    /// Hash over the subscribed topics' metadata, which is how a subscription
+    /// change is detected.
+    int64_t metadata_hash() const { return _metadata_hash; }
+
+    const members_map& members() const { return _members; }
+
+    /// The group's committed offsets and transaction state.
+    offset_store& offsets() { return _offset_store; }
+    const offset_store& offsets() const { return _offset_store; }
+
+    /// \brief The group's lifecycle label, derived from the epochs.
+    ///
+    /// Not stored: a group has no state to set, so this is recomputed on every
+    /// call from the epochs and each member's progress.
+    consumer_group_state state() const;
+
+    /// The mutators below are what applying a committed record does. Each
+    /// corresponds to one of the group's persisted record types, so a caller
+    /// stores what the log says rather than computing it here.
+
+    void set_epoch(kafka::group_epoch epoch) { _epoch = epoch; }
+
+    void set_metadata_hash(int64_t hash) { _metadata_hash = hash; }
+
+    void set_assignment_epoch(kafka::assignment_epoch epoch) {
+        _assignment_epoch = epoch;
+    }
+
+    /// Add the member, or replace it if the group already has one by that id.
+    void upsert_member(consumer_group_member member);
+
+    /// \returns whether a member was removed.
+    bool erase_member(const kafka::member_id& id) {
+        return _members.erase(id) > 0;
+    }
+
+    /// Applying the group's tombstone. An offset commit that lands after this
+    /// does not apply its offsets, so a deleted group cannot be resurrected by
+    /// a write that was already in flight.
+    void mark_removed() { _removed = true; }
+
+    bool removed() const { return _removed; }
+
+    /// Stops the offset state, which is expiring transactions on a timer.
+    ss::future<> stop() { return _offset_store.stop(); }
+
+private:
+    kafka::group_id _id;
+    kafka::group_epoch _epoch{0};
+    kafka::assignment_epoch _assignment_epoch{0};
+    int64_t _metadata_hash{0};
+    bool _removed{false};
+    members_map _members;
+    offset_store _offset_store;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1233,6 +1233,22 @@ ss::future<> group_manager::do_recover_group(
   ss::lw_shared_ptr<attached_partition> p,
   group_id group_id,
   group_stm group_stm) {
+    /*
+     * A group with committed offsets and nothing else is a legal classic
+     * simple group, so recovery would mint one for any id that has offsets --
+     * including a consumer group's, whose commits are ordinary offset records.
+     * The state machine that owns the id says which protocol it belongs to.
+     */
+    if (
+      auto stm = consumer_groups(p->partition);
+      stm && stm->get_group(group_id)) {
+        vlog(
+          cg_klog.debug,
+          "Not recovering {} as a classic group: the id belongs to a consumer "
+          "group",
+          group_id);
+        co_return;
+    }
     if (group_stm.has_data()) {
         auto group = get_group(group_id);
         vlog(
@@ -1974,6 +1990,48 @@ group_manager::describe_partition_producers(const model::ntp& ntp) {
     return response;
 }
 
+ss::future<consumer_group_heartbeat_response>
+group_manager::consumer_group_heartbeat(consumer_group_heartbeat_request&& r) {
+    // Same checks the classic group APIs get: a usable group id, the group not
+    // blocked, this node the leader, its term unchanged, and recovery of the
+    // partition's groups finished.
+    if (
+      auto error = validate_group_status(
+        r.ntp, r.data.group_id, consumer_group_heartbeat_api::key, false);
+      error != error_code::none) {
+        co_return consumer_group_heartbeat_response(r, error);
+    }
+
+    // The group-id namespace is shared, and an id belongs to one protocol or
+    // the other. A classic group is not converted in place, so a heartbeat
+    // naming one is refused rather than creating a second group under its id.
+    // A consumer group of this id wins: recovery mints a classic group for any
+    // id that merely has committed offsets, which a consumer group's own
+    // commits satisfy, and that phantom must not refuse the group its
+    // heartbeats.
+    auto owned_here = [this, &r] {
+        auto it = _partitions.find(r.ntp);
+        return it != _partitions.end() && consumer_groups(it->second->partition)
+               && consumer_groups(it->second->partition)
+                    ->get_group(r.data.group_id);
+    };
+    if (get_group(r.data.group_id) && !owned_here()) {
+        vlog(
+          cg_klog.debug,
+          "consumer heartbeat for {} refused: the id belongs to a classic "
+          "group",
+          r.data.group_id);
+        co_return consumer_group_heartbeat_response(
+          r, error_code::group_id_not_found);
+    }
+
+    // A consumer group's state is owned by a state machine that does not exist
+    // yet, so there is nothing to serve the heartbeat from. The request
+    // validation the protocol needs arrives with the live path.
+    co_return consumer_group_heartbeat_response(
+      r, error_code::unsupported_version);
+}
+
 ss::future<std::error_code> group_manager::empty_and_delete_groups(
   const model::ntp& co_ntp,
   const chunked_vector<group_id>& groups,
@@ -2139,6 +2197,15 @@ bool group_manager::valid_group_id(const group_id& group, api_key api) {
  * TODO
  * - check for group being shutdown
  */
+ss::shared_ptr<consumer_group_stm> group_manager::consumer_groups(
+  const ss::lw_shared_ptr<cluster::partition>& partition) {
+    return partition->raft()->stm_manager()->get<consumer_group_stm>();
+}
+
+bool group_manager::is_consumer_group_api(api_key api) {
+    return api == consumer_group_heartbeat_api::key;
+}
+
 error_code group_manager::validate_group_status(
   const model::ntp& ntp,
   const group_id& group,
@@ -2176,6 +2243,28 @@ error_code group_manager::validate_group_status(
               api,
               ntp);
             return error_code::not_coordinator;
+        }
+
+        /**
+         * The group-id namespace is shared and an id belongs to one protocol
+         * or the other. A classic request naming an id the consumer protocol
+         * owns is refused the way a consumer heartbeat naming a classic id is;
+         * serving it would put two coordinators on one group, each overwriting
+         * the other's records. Kafka refuses the same case with
+         * GROUP_ID_NOT_FOUND while its migration policy forbids a conversion.
+         */
+        if (!is_consumer_group_api(api)) {
+            if (
+              auto stm = consumer_groups(p->partition);
+              stm && stm->get_group(group)) {
+                vlog(
+                  cg_klog.debug,
+                  "Group {} operation {} refused: the id belongs to a consumer "
+                  "group",
+                  group,
+                  api);
+                return error_code::group_id_not_found;
+            }
         }
         /**
          * Check if term changed, this can happen if a node that stepped down

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -17,6 +17,7 @@
 #include "cluster/offsets_snapshot.h"
 #include "cluster/topic_table.h"
 #include "container/chunked_vector.h"
+#include "kafka/protocol/consumer_group_heartbeat.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/heartbeat.h"
 #include "kafka/protocol/join_group.h"
@@ -30,6 +31,7 @@
 #include "kafka/protocol/sync_group.h"
 #include "kafka/protocol/txn_offset_commit.h"
 #include "kafka/protocol/types.h"
+#include "kafka/server/consumer_group_stm.h"
 #include "kafka/server/fwd.h"
 #include "kafka/server/group.h"
 #include "kafka/server/group_recovery_consumer.h"
@@ -159,6 +161,12 @@ public:
     ss::future<txn_offset_commit_response>
     txn_offset_commit(txn_offset_commit_request&& request);
 
+    /// Serve a consumer-protocol heartbeat. The group's state belongs to a
+    /// state machine that does not exist yet, so this resolves the coordinator
+    /// and refuses a group-id the classic protocol already owns.
+    ss::future<consumer_group_heartbeat_response>
+    consumer_group_heartbeat(consumer_group_heartbeat_request&& request);
+
     ss::future<cluster::commit_group_tx_reply>
     commit_tx(cluster::commit_group_tx_request&& request);
 
@@ -242,6 +250,16 @@ private:
         }
         return nullptr;
     }
+
+    /// The consumer groups of a partition, whichever replica this is. The
+    /// group-id namespace is shared with the classic protocol, so both
+    /// protocols' entry points consult the other's ownership of an id.
+    static ss::shared_ptr<consumer_group_stm>
+    consumer_groups(const ss::lw_shared_ptr<cluster::partition>&);
+
+    /// Whether the api belongs to the consumer protocol, whose requests are
+    /// the ones a consumer-owned group id is for.
+    static bool is_consumer_group_api(api_key);
 
     cluster::notification_id_type _manage_notify_handle;
     cluster::notification_id_type _unmanage_notify_handle;

--- a/src/v/kafka/server/group_router.cc
+++ b/src/v/kafka/server/group_router.cc
@@ -318,6 +318,12 @@ group_router::txn_offset_commit(txn_offset_commit_request&& request) {
     return route(std::move(request), &group_manager::txn_offset_commit);
 }
 
+ss::future<consumer_group_heartbeat_response>
+group_router::consumer_group_heartbeat(
+  consumer_group_heartbeat_request&& request) {
+    return route(std::move(request), &group_manager::consumer_group_heartbeat);
+}
+
 ss::future<cluster::commit_group_tx_reply>
 group_router::commit_tx(cluster::commit_group_tx_request request) {
     return route_tx(std::move(request), &group_manager::commit_tx);

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "cluster/shard_table.h"
 #include "container/chunked_vector.h"
+#include "kafka/protocol/consumer_group_heartbeat.h"
 #include "kafka/protocol/describe_groups.h"
 #include "kafka/protocol/heartbeat.h"
 #include "kafka/protocol/join_group.h"
@@ -76,6 +77,9 @@ public:
 
     ss::future<txn_offset_commit_response>
     txn_offset_commit(txn_offset_commit_request&& request);
+
+    ss::future<consumer_group_heartbeat_response>
+    consumer_group_heartbeat(consumer_group_heartbeat_request&& request);
 
     ss::future<cluster::commit_group_tx_reply>
     commit_tx(cluster::commit_group_tx_request request);

--- a/src/v/kafka/server/handlers/consumer_group_heartbeat.cc
+++ b/src/v/kafka/server/handlers/consumer_group_heartbeat.cc
@@ -27,6 +27,12 @@ ss::future<response_ptr> consumer_group_heartbeat_handler::handle(
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
 
+    ctx.connection()->attributes().last_group_id.update(request.data.group_id);
+    ctx.connection()->attributes().last_group_instance_id.update(
+      request.data.instance_id);
+    ctx.connection()->attributes().last_group_member_id.update(
+      kafka::member_id(request.data.member_id));
+
     consumer_group_heartbeat_response resp;
 
     if (!details::consumer_group_protocol_enabled(
@@ -38,11 +44,30 @@ ss::future<response_ptr> consumer_group_heartbeat_handler::handle(
         co_return co_await ctx.respond(std::move(resp));
     }
 
-    // TODO(kip-848): replace with the live path through to the group routing
-    // code. Unreachable until then: the gate above is always closed.
-    resp.data.error_code = error_code::unsupported_version;
-    resp.data.error_message = "ConsumerGroupHeartbeat is not implemented";
-    co_return co_await ctx.respond(std::move(resp));
+    if (unlikely(ctx.recovery_mode_enabled())) {
+        co_return co_await ctx.respond(consumer_group_heartbeat_response(
+          request, error_code::policy_violation));
+    }
+
+    // authorized() first, so the audit event carries its outcome
+    auto authz = ctx.authorized(
+      security::acl_operation::read, request.data.group_id);
+
+    if (!ctx.audit()) {
+        co_return co_await ctx.respond(consumer_group_heartbeat_response(
+          request, error_code::broker_not_available));
+    }
+
+    if (!authz) {
+        co_return co_await ctx.respond(consumer_group_heartbeat_response(
+          request, error_code::group_authorization_failed));
+    }
+
+    // The group manager resolves the coordinator and rejects a group-id the
+    // classic protocol owns. It cannot yet serve a heartbeat, so a request
+    // that passes those checks still comes back unimplemented.
+    co_return co_await ctx.respond(
+      co_await ctx.groups().consumer_group_heartbeat(std::move(request)));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -298,6 +298,25 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "consumer_group_test",
+    timeout = "short",
+    srcs = [
+        "consumer_group_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster:tx_protocol_types",
+        "//src/v/config",
+        "//src/v/features",
+        "//src/v/kafka/server",
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "offset_store_test",
     timeout = "short",
     srcs = [

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -411,6 +411,7 @@ redpanda_cc_btest(
         "//src/v/container:chunked_vector",
         "//src/v/kafka/client:transport",
         "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:consumer_group_heartbeat",
         "//src/v/kafka/protocol:describe_groups",
         "//src/v/kafka/protocol:find_coordinator",
         "//src/v/kafka/protocol:join_group",

--- a/src/v/kafka/server/tests/consumer_group_test.cc
+++ b/src/v/kafka/server/tests/consumer_group_test.cc
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/tx_protocol_types.h"
+#include "config/configuration.h"
+#include "features/feature_table.h"
+#include "kafka/server/consumer_group.h"
+#include "kafka/server/offset_writer.h"
+#include "kafka/server/tx_coordinator_client.h"
+#include "model/fundamental.h"
+#include "raft/errc.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/rwlock.hh>
+#include <seastar/core/sharded.hh>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <stdexcept>
+
+namespace kafka {
+namespace {
+
+const group_id test_group{"test-group"};
+
+/// The group's offset state is not what these tests cover, so its writer and
+/// coordinator client do nothing.
+class unused_writer final : public offset_writer {
+public:
+    model::term_id term() const final { return model::term_id{1}; }
+
+    ss::future<result<raft::replicate_result>>
+    replicate(model::record_batch, model::term_id) final {
+        return ss::make_exception_future<result<raft::replicate_result>>(
+          std::runtime_error("unexpected replicate"));
+    }
+
+    ss::future<result<raft::replicate_result>>
+    replicate(chunked_vector<model::record_batch>, model::term_id) final {
+        return ss::make_exception_future<result<raft::replicate_result>>(
+          std::runtime_error("unexpected replicate"));
+    }
+
+    raft::replicate_stages replicate_in_stages(
+      chunked_vector<model::record_batch>, model::term_id) final {
+        return raft::replicate_stages(raft::errc::not_leader);
+    }
+
+    ss::future<> maybe_step_down(model::term_id, std::string_view) final {
+        return ss::now();
+    }
+};
+
+class unused_tx_coordinator final : public tx_coordinator_client {
+public:
+    ss::future<cluster::try_abort_reply> try_abort(
+      model::partition_id, model::producer_identity, model::tx_seq) final {
+        return ss::make_exception_future<cluster::try_abort_reply>(
+          std::runtime_error("unexpected try_abort"));
+    }
+};
+
+consumer_group_member member_at(
+  const ss::sstring& id,
+  member_epoch epoch,
+  consumer_group_member_state state = consumer_group_member_state::stable) {
+    return {
+      .id = kafka::member_id(id),
+      .subscription = {.client_id = kafka::client_id("c")},
+      .epoch = epoch,
+      .previous_epoch = epoch,
+      .state = state,
+    };
+}
+
+struct consumer_group_test : seastar_test {
+    ss::future<> SetUpAsync() override {
+        co_await feature_table.start();
+        co_await feature_table.invoke_on_all(
+          [](features::feature_table& f) { f.testing_activate_all(); });
+    }
+
+    ss::future<> TearDownAsync() override {
+        co_await group.stop();
+        co_await feature_table.stop();
+    }
+
+    ss::sharded<features::feature_table> feature_table;
+
+    ss::lw_shared_ptr<ss::rwlock> catchup_lock
+      = ss::make_lw_shared<ss::rwlock>();
+
+    consumer_group group{
+      test_group,
+      config::shard_local_cfg(),
+      catchup_lock,
+      std::make_unique<unused_writer>(),
+      model::term_id(1),
+      std::make_unique<unused_tx_coordinator>(),
+      feature_table};
+};
+
+TEST_F(consumer_group_test, a_new_group_is_empty) {
+    ASSERT_EQ(group.id(), test_group);
+    ASSERT_EQ(group.epoch(), group_epoch(0));
+    ASSERT_EQ(group.assignment_epoch(), assignment_epoch(0));
+    ASSERT_TRUE(group.members().empty());
+    ASSERT_EQ(group.state(), consumer_group_state::empty);
+}
+
+TEST_F(
+  consumer_group_test, a_group_with_no_members_is_empty_whatever_the_epoch) {
+    // empty wins over assigning: with nobody to assign to, the epochs say
+    // nothing about the group.
+    group.set_epoch(group_epoch(7));
+    ASSERT_EQ(group.state(), consumer_group_state::empty);
+}
+
+TEST_F(consumer_group_test, a_group_owed_an_assignment_is_assigning) {
+    group.upsert_member(member_at("m1", member_epoch(1)));
+    group.set_epoch(group_epoch(2));
+    group.set_assignment_epoch(assignment_epoch(1));
+
+    ASSERT_EQ(group.state(), consumer_group_state::assigning);
+}
+
+TEST_F(consumer_group_test, a_group_whose_members_lag_the_target_reconciles) {
+    group.upsert_member(member_at("m1", member_epoch(2)));
+    group.upsert_member(member_at("m2", member_epoch(1)));
+    group.set_epoch(group_epoch(2));
+    group.set_assignment_epoch(assignment_epoch(2));
+
+    ASSERT_EQ(group.state(), consumer_group_state::reconciling);
+}
+
+TEST_F(consumer_group_test, a_group_is_stable_once_every_member_catches_up) {
+    group.upsert_member(member_at("m1", member_epoch(2)));
+    group.upsert_member(member_at("m2", member_epoch(1)));
+    group.set_epoch(group_epoch(2));
+    group.set_assignment_epoch(assignment_epoch(2));
+    ASSERT_EQ(group.state(), consumer_group_state::reconciling);
+
+    group.upsert_member(member_at("m2", member_epoch(2)));
+
+    ASSERT_EQ(group.state(), consumer_group_state::stable);
+}
+
+TEST_F(
+  consumer_group_test,
+  a_member_at_the_epoch_still_holding_partitions_is_not_reconciled) {
+    // The member's epoch was bumped to the target, but it is waiting on
+    // partitions their previous owner has not released yet, so the group is
+    // still converging even though every epoch matches.
+    group.upsert_member(member_at(
+      "m1",
+      member_epoch(2),
+      consumer_group_member_state::unreleased_partitions));
+    group.set_epoch(group_epoch(2));
+    group.set_assignment_epoch(assignment_epoch(2));
+
+    ASSERT_EQ(group.state(), consumer_group_state::reconciling);
+
+    group.upsert_member(member_at("m1", member_epoch(2)));
+    ASSERT_EQ(group.state(), consumer_group_state::stable);
+}
+
+TEST_F(consumer_group_test, a_member_owing_partitions_back_is_not_reconciled) {
+    group.upsert_member(member_at(
+      "m1",
+      member_epoch(2),
+      consumer_group_member_state::unrevoked_partitions));
+    group.set_epoch(group_epoch(2));
+    group.set_assignment_epoch(assignment_epoch(2));
+
+    ASSERT_EQ(group.state(), consumer_group_state::reconciling);
+}
+
+TEST_F(consumer_group_test, a_removed_group_reports_itself_removed) {
+    ASSERT_FALSE(group.removed());
+    group.mark_removed();
+    ASSERT_TRUE(group.removed());
+}
+
+TEST_F(consumer_group_test, upserting_a_member_replaces_it) {
+    group.upsert_member(member_at("m1", member_epoch(1)));
+    group.upsert_member(member_at("m1", member_epoch(4)));
+
+    ASSERT_EQ(group.members().size(), 1);
+    ASSERT_EQ(
+      group.members().at(kafka::member_id("m1")).epoch, member_epoch(4));
+}
+
+TEST_F(consumer_group_test, erasing_the_last_member_empties_the_group) {
+    group.upsert_member(member_at("m1", member_epoch(1)));
+    group.upsert_member(member_at("m2", member_epoch(1)));
+    group.set_epoch(group_epoch(1));
+    group.set_assignment_epoch(assignment_epoch(1));
+    ASSERT_EQ(group.state(), consumer_group_state::stable);
+
+    ASSERT_TRUE(group.erase_member(kafka::member_id("m2")));
+    ASSERT_EQ(group.state(), consumer_group_state::stable);
+
+    ASSERT_TRUE(group.erase_member(kafka::member_id("m1")));
+    ASSERT_EQ(group.state(), consumer_group_state::empty);
+
+    // a member the group does not have
+    ASSERT_FALSE(group.erase_member(kafka::member_id("m1")));
+}
+
+TEST_F(consumer_group_test, state_names_match_the_kafka_names) {
+    ASSERT_EQ(to_string_view(consumer_group_state::empty), "Empty");
+    ASSERT_EQ(to_string_view(consumer_group_state::assigning), "Assigning");
+    ASSERT_EQ(to_string_view(consumer_group_state::reconciling), "Reconciling");
+    ASSERT_EQ(to_string_view(consumer_group_state::stable), "Stable");
+    ASSERT_EQ(to_string_view(consumer_group_state::dead), "Dead");
+}
+
+} // namespace
+} // namespace kafka

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -12,6 +12,7 @@
 #include "cluster/security_frontend.h"
 #include "container/chunked_vector.h"
 #include "kafka/client/transport.h"
+#include "kafka/protocol/consumer_group_heartbeat.h"
 #include "kafka/protocol/describe_groups.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/find_coordinator.h"
@@ -86,6 +87,31 @@ struct consumer_offsets_fixture : public redpanda_thread_fixture {
         client.shutdown();
     }
 
+    /// Joins a group over the classic protocol, so a classic group owns the
+    /// id. Joins as a static member, which skips the member-id round trip a
+    /// plain join needs first.
+    void join_classic_group(
+      kafka::client::transport& client,
+      const kafka::group_id& group,
+      const kafka::group_instance_id& instance) {
+        tests::cooperative_spin_wait_with_timeout(
+          30s,
+          [&client, &group, &instance] {
+              auto req = make_join_group_request(
+                unknown_member_id, group(), {"p1"}, "consumer");
+              req.data.group_instance_id = instance;
+              return client.dispatch(std::move(req), kafka::api_version(5))
+                .then([](join_group_response resp) {
+                    BOOST_REQUIRE(
+                      resp.data.error_code == kafka::error_code::none
+                      || resp.data.error_code
+                           == kafka::error_code::not_coordinator);
+                    return resp.data.error_code == kafka::error_code::none;
+                });
+          })
+          .get();
+    }
+
     void create_user(const ss::sstring& user, const ss::sstring& pass) {
         auto creds = security::scram_sha256::make_credentials(
           pass, security::scram_sha256::min_iterations);
@@ -148,6 +174,47 @@ FIXTURE_TEST(join_empty_group_static_member, consumer_offsets_fixture) {
               return resp.data.error_code == kafka::error_code::none
                      && resp.data.member_id != unknown_member_id;
           });
+    }).get();
+}
+
+FIXTURE_TEST(
+  consumer_heartbeat_refuses_a_classic_group_id, consumer_offsets_fixture) {
+    kafka::group_instance_id gr("instance-1");
+    wait_for_consumer_offsets_topic(gr);
+    auto client = make_kafka_client().get();
+    auto deferred = ss::defer([&client] {
+        client.stop().then([&client] { client.shutdown(); }).get();
+    });
+    client.connect().get();
+
+    const kafka::group_id classic{"classic-group"};
+    join_classic_group(client, classic, gr);
+
+    // the heartbeat handler's feature gate is closed while the protocol is
+    // incomplete, so the router is driven directly
+    const auto heartbeat = [this](const kafka::group_id& group) {
+        kafka::consumer_group_heartbeat_request req;
+        req.data.group_id = group;
+        req.data.member_id = "m1";
+        req.data.member_epoch = kafka::member_epoch(0);
+        return app.group_router.local()
+          .consumer_group_heartbeat(std::move(req))
+          .get()
+          .data.error_code;
+    };
+
+    BOOST_REQUIRE_EQUAL(
+      heartbeat(classic), kafka::error_code::group_id_not_found);
+
+    // An id no classic group owns reaches the end of the path instead, so the
+    // refusal is a decision about the id and not the only answer the entry
+    // point gives. This id hashes to a partition of its own, whose leadership
+    // and group loading nothing here has waited for, so the coordinator
+    // checks are retried the way the classic half of the test retries them.
+    const kafka::group_id consumer{"consumer-group"};
+    tests::cooperative_spin_wait_with_timeout(30s, [&heartbeat, &consumer] {
+        return ss::make_ready_future<bool>(
+          heartbeat(consumer) == kafka::error_code::unsupported_version);
     }).get();
 }
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

KIP-848 Phase 1 adds consumer-protocol groups alongside the classic coordinator. This is the first coordinator piece: the `consumer_group` type beside the classic `group`, and the dispatch path that carries ConsumerGroupHeartbeat to the group coordinator.

- named types for the protocol's three epochs (group, assignment, member), wired into the generated schemas
- `consumer_group`: the epochs, the members, and a lifecycle state derived from them rather than stored, composing `offset_store` for committed offsets and transactions
- ConsumerGroupHeartbeat routed through `group_router` to a `group_manager` entry point that resolves the coordinator and rejects a group id the classic protocol owns; serving the request arrives with CORE-16808, so a request that passes the checks is answered UNSUPPORTED_VERSION for now
- the handler runs the same recovery-mode, audit and authorization checks the classic group handlers run

Unit tests cover the type and the state derivation; an integration test covers the classic-id refusal end to end.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
