### PR TITLE
bazel: fetch pip wheels via the Bazel downloader

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -123,7 +123,7 @@ python.toolchain(
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
-    extra_pip_args = ["--require-hashes"],
+    experimental_index_url = "https://pypi.org/simple",
     hub_name = "python_deps",
     python_version = "3.12",
     requirements_lock = "//bazel/thirdparty:requirements.txt",


### PR DESCRIPTION
rules_python's whl_library shells out to a vendored pip to download wheels,
which fails frequently when PyPI's CDN (files.pythonhosted.org) returns 502s.

Between 2026-08-15 and 2026-08-18 this accounted for 90 of the 347 failed
jobs in the redpanda and vtools pipelines, 58 of them in whl_library.

Setting experimental_index_url switches whl_library to its rctx.download
branch and skips pip for wheel fetching: effective bazel will do the
download in the "bazel way": this means it gets cached through bazel-remote
via the asset cache feature (which we recently turned on).

--require-hashes goes away: it was effectively unused as rules_python strips it,
and it can break for "source dist" libraries, which we don't currently
materialize in the build but which exist in our build. The hashes are
already checked in the lockfile.

This is only a partial fix because not all python used in CI goes through bazel,
invoke python/uv directly in various places, but it reduces the vulnerable
calls by a lot.

Fixes [CORE-17093].

[CORE-17093]: https://redpandadata.atlassian.net/browse/CORE-17093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none