### PR TITLE
bazel: cap the http downloader retry backoff

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,8 +2,12 @@ common --registry=https://bcr.bazel.build
 common --extra_toolchains=@current_llvm_toolchain//:all
 
 # Triple repo downloader retries to try working around github flakiness.
+# Cap the per-retry backoff: it doubles from 100ms on every attempt and is
+# uncapped by default, so 24 attempts would sleep for days against a host that
+# keeps returning 5xx.
 common --experimental_repository_downloader_retries=15
 common --http_connector_attempts=24
+common --http_connector_retry_max_timeout=15s
 
 # Multi-GB CAS uploads don't fit in the 60s default deadline: CORE-16940.
 build --remote_timeout=600


### PR DESCRIPTION
`.bazelrc` sets `--http_connector_attempts=24` to ride out github flakiness, but leaves `--http_connector_retry_max_timeout` at its `0s` default, which means no cap. Bazel's `HttpConnector` sleeps `100ms * 2^attempt` between tries (jittered), so the 23 sleeps behind 24 attempts total roughly **9.7 days**, the final sleep alone being about 4.9 days. Against a host that keeps returning 5xx, a fetch stops behaving like a retry loop and starts behaving like a hang: the job dies on the Buildkite step timeout rather than failing with a useful error.

This caps each sleep at 15s, bounding the total to about 4.2 minutes while still leaving far more headroom than Bazel's 8-attempt default (~12.7s).

| cap | total backoff across 24 attempts |
| --- | --- |
| `0s` (today, uncapped) | ~9.7 days |
| `15s` (this change) | ~4.2 min |

Measured against a local server returning 502 unconditionally, using `repository_ctx.download`:

| attempts | cap | wall time |
| --- | --- | --- |
| 10 | `0s` | 60.9s |
| 10 | `1s` | 9.8s |
| 14 | `2s` | 22.0s |
| 14 | `0s` | still sleeping past 10 min (model: 13.7 min) |

Bazel's connector retries HTTP 502 specifically (along with other 5xx, 403, 408, 429), so this path is reachable from any 5xx-ing upstream, not only from connection errors. Worth noting that `--experimental_repository_downloader_retries=15` on the adjacent line does *not* cover 5xx — its retry predicate only matches `ContentLengthMismatchException`, `SocketException` and `UnknownHostException` — so `--http_connector_attempts` is the knob actually governing this behaviour.

Applies to every `http_archive` in the build. Independent of the rules_python wheel-fetching change in CORE-17093 (#31623), which moves pip wheel downloads onto this same downloader and so also benefits.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none