### PR TITLE
serde: fix scope-guard underflow and add decode-side fuzzing

### DIFF
--- a/src/v/serde/rw/map.h
+++ b/src/v/serde/rw/map.h
@@ -41,7 +41,7 @@ void tag_invoke(
     using Type = std::decay_t<decltype(t)>;
     const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
     if constexpr (Reservable<Type>) {
-        t.reserve(size);
+        reserve_from_wire(t, size, in);
     }
     for (auto i = 0U; i < size; ++i) {
         typename Type::key_type key;

--- a/src/v/serde/rw/reservable.h
+++ b/src/v/serde/rw/reservable.h
@@ -9,9 +9,25 @@
 
 #pragma once
 
+#include "bytes/iobuf_parser.h"
+
+#include <algorithm>
+#include <cstddef>
+
 namespace serde {
 
 template<typename T>
 concept Reservable = requires(T t) { t.reserve(0U); };
+
+// Reserves room for an element count that came off the wire. Encoding an
+// element always costs at least one byte, so a count larger than the bytes left
+// in the parser cannot be honest, and reserving it would turn a corrupt size
+// prefix into an allocation of any size the prefix asks for. The caller still
+// reads exactly count elements and so still rejects the input when the bytes
+// run out; this only bounds the capacity taken up front.
+template<Reservable T>
+void reserve_from_wire(T& t, std::size_t count, const iobuf_parser& in) {
+    t.reserve(std::min(count, in.bytes_left()));
+}
 
 } // namespace serde

--- a/src/v/serde/rw/scalar.h
+++ b/src/v/serde/rw/scalar.h
@@ -30,13 +30,20 @@ void tag_invoke(
   tag_t<read_tag>, iobuf_parser& in, T& t, const std::size_t bytes_left_limit) {
     using Type = std::decay_t<T>;
 
-    if (unlikely(in.bytes_left() - bytes_left_limit < sizeof(Type))) {
+    // bytes_left_limit is where bytes_left() is expected to be when the current
+    // serde scope ends. Comparing against limit + sizeof(Type), rather than
+    // subtracting the limit from bytes_left(), also rejects a parser that is
+    // already past the scope end: the subtraction wraps to near SIZE_MAX there
+    // and admits a read of bytes belonging to the enclosing scope. Limits
+    // derive from buffer sizes, so the addition cannot overflow.
+    if (unlikely(in.bytes_left() < bytes_left_limit + sizeof(Type))) {
         throw serde_exception(fmt_with_ctx(
           ssx::sformat,
-          "reading type {} of size {}: {} bytes left",
+          "reading type {} of size {}: {} bytes left, bytes_left_limit={}",
           type_str<Type>(),
           sizeof(Type),
-          in.bytes_left()));
+          in.bytes_left(),
+          bytes_left_limit));
     }
 
     if constexpr (sizeof(Type) == 1) {

--- a/src/v/serde/rw/set.h
+++ b/src/v/serde/rw/set.h
@@ -43,7 +43,7 @@ void tag_invoke(
 
     const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
     if constexpr (Reservable<Type>) {
-        t.reserve(size);
+        reserve_from_wire(t, size, in);
     }
     for (auto i = 0U; i < size; ++i) {
         auto elem = read_nested<typename Type::key_type>(in, bytes_left_limit);

--- a/src/v/serde/rw/vector.h
+++ b/src/v/serde/rw/vector.h
@@ -47,7 +47,7 @@ void tag_invoke(
 
     const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
     if constexpr (Reservable<decltype(t)>) {
-        t.reserve(size);
+        reserve_from_wire(t, size, in);
     }
     for (auto i = 0U; i < size; ++i) {
         t.push_back(read_nested<value_type>(in, bytes_left_limit));

--- a/src/v/serde/test/BUILD
+++ b/src/v/serde/test/BUILD
@@ -94,11 +94,23 @@ redpanda_cc_fuzz_test(
     args = [
         "-max_total_time=60",
         "-rss_limit_mb=8192",
+        # The decode modes in fuzz.cc need inputs long enough to hold a nested
+        # envelope. libFuzzer tries short inputs first and only raises the limit
+        # when coverage stops growing, which at the default rate of 100 leaves it
+        # around 20 bytes for the whole run; 3 reaches the cap within a minute
+        # while keeping short inputs first.
+        "-max_len=512",
+        "-len_control=3",
     ],
     deps = [
         ":generated_structs",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
         "//src/v/reflection:type_traits",
         "//src/v/serde",
+        "//src/v/serde:iobuf",
+        "//src/v/serde:optional",
+        "//src/v/serde:sstring",
         "//src/v/serde:vector",
     ],
 )
@@ -110,7 +122,13 @@ redpanda_cc_binary(
     defines = ["MAIN=1"],
     deps = [
         ":generated_structs",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
         "//src/v/reflection:type_traits",
         "//src/v/serde",
+        "//src/v/serde:iobuf",
+        "//src/v/serde:optional",
+        "//src/v/serde:sstring",
+        "//src/v/serde:vector",
     ],
 )

--- a/src/v/serde/test/fuzz.cc
+++ b/src/v/serde/test/fuzz.cc
@@ -1,10 +1,28 @@
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
 #include "reflection/type_traits.h"
+#include "serde/envelope.h"
+#include "serde/read_header.h"
+#include "serde/rw/envelope.h"
+#include "serde/rw/iobuf.h"
+#include "serde/rw/optional.h"
+#include "serde/rw/rw.h"
+#include "serde/rw/scalar.h"
+#include "serde/rw/sstring.h"
+#include "serde/rw/vector.h"
+#include "serde/serde_exception.h"
+#include "serde/serde_size_t.h"
 #include "serde/test/generated_structs.h"
+#include "serde/type_str.h"
 
 #if defined(MAIN)
 #include <fstream>
 #endif
 #include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 constexpr const auto max_depth = 2;
 constexpr const auto max_vector_size = 6;
@@ -202,6 +220,267 @@ bool test_version_upgrade(
       generations);
 }
 
+// ---------------------------------------------------------------------------
+// Decode-side fuzzing.
+//
+// Everything above is a round trip: the decoder only ever sees the output of
+// its own writer, so every size prefix agrees with the bytes that follow it and
+// no malformed encoding is ever tried. The generated structs are also all
+// serde_fields() envelopes, and serde/rw/envelope.h forwards the *incoming*
+// bytes_left_limit to generated fields, so the limit stays at the 0 that
+// read<T>() seeds and the bounds guards are never asked about a real scope end.
+//
+// This half serializes a valid value, corrupts the bytes and decodes the
+// result. The types below are hand-written for two reasons: their readers
+// forward their own h._bytes_left_limit the way ~40 production call sites do
+// (security::acl.cc, raft/types.cc, cluster/controller_snapshot.cc, ...), and
+// they check the scope invariant around every field read.
+// ---------------------------------------------------------------------------
+
+// The invariant a nested read is entitled to assume is
+// bytes_left() >= bytes_left_limit: the parser has not yet passed the end of
+// the scope it is reading in. A preceding variable-length field can break it,
+// because sstring.h and iobuf.h consume their whole declared length in one step
+// without consulting the limit, so a length prefix that is too large walks the
+// parser past the scope end while leaving it inside the buffer. What must not
+// happen is a read *completing* from there: those bytes belong to the enclosing
+// scope, and a field decoded from them is silently wrong. The scalar guard is
+// what has to reject it.
+template<typename T>
+void read_scoped(iobuf_parser& in, T& t, const std::size_t bytes_left_limit) {
+    const auto before = in.bytes_left();
+    serde::read_nested(in, t, bytes_left_limit);
+    if (before < bytes_left_limit) {
+        std::cout
+          << "read of " << serde::type_str<T>() << " started "
+          << bytes_left_limit - before
+          << " bytes past the end of its serde scope (bytes_left=" << before
+          << ", bytes_left_limit=" << bytes_left_limit
+          << ") and completed: the field was decoded from the enclosing "
+             "scope's bytes\n"
+          << std::flush;
+        __builtin_trap();
+    }
+}
+
+// Offsets of the size prefixes of the encoding written most recently. mutate()
+// aims at these: a prefix that lies is the only input that can push a decode
+// past a scope end, since every other read is bounded by a scalar guard.
+std::vector<std::size_t> size_prefix_offsets;
+
+// Each variable-length field is followed by a one-byte scalar, which is the
+// read that gets to ask the guard whether the scope still has room. This is the
+// shape of the chain in security::acl_binding_filter::serde_read, where an
+// optional<sstring> is followed by an optional whose first read is a bool.
+struct scoped_leaf
+  : serde::envelope<scoped_leaf, serde::version<0>, serde::compat_version<0>> {
+    std::vector<std::int32_t> _vec;
+    std::int8_t _a{};
+    iobuf _buf;
+    std::int8_t _b{};
+    std::optional<ss::sstring> _opt;
+    std::int8_t _c{};
+    ss::sstring _str;
+    std::int8_t _d{};
+
+    template<std::size_t Generation>
+    auto get_generation() {
+        static_assert(Generation == 0);
+        return std::tie(_vec, _a, _buf, _b, _opt, _c, _str, _d);
+    }
+
+    void serde_write(iobuf& out) const {
+        size_prefix_offsets.push_back(out.size_bytes());
+        serde::write(out, _vec);
+        serde::write(out, _a);
+        size_prefix_offsets.push_back(out.size_bytes());
+        serde::write(out, _buf.copy());
+        serde::write(out, _b);
+        // Past the presence flag, where the string's own prefix begins when the
+        // optional is engaged.
+        size_prefix_offsets.push_back(out.size_bytes() + 1);
+        serde::write(out, _opt);
+        serde::write(out, _c);
+        size_prefix_offsets.push_back(out.size_bytes());
+        serde::write(out, _str);
+        serde::write(out, _d);
+    }
+
+    void serde_read(iobuf_parser& in, const serde::header& h) {
+        read_scoped(in, _vec, h._bytes_left_limit);
+        read_scoped(in, _a, h._bytes_left_limit);
+        read_scoped(in, _buf, h._bytes_left_limit);
+        read_scoped(in, _b, h._bytes_left_limit);
+        read_scoped(in, _opt, h._bytes_left_limit);
+        read_scoped(in, _c, h._bytes_left_limit);
+        read_scoped(in, _str, h._bytes_left_limit);
+        read_scoped(in, _d, h._bytes_left_limit);
+    }
+};
+
+// _leaf is followed by more fields, so its envelope does not end at the end of
+// the buffer and its reader sees a nonzero bytes_left_limit. These fields are
+// also the bytes an overrunning field inside _leaf steals.
+struct scoped_outer
+  : serde::envelope<scoped_outer, serde::version<0>, serde::compat_version<0>> {
+    scoped_leaf _leaf;
+    std::int64_t _tail_n{};
+    ss::sstring _tail_str;
+    std::vector<std::int64_t> _tail_vec;
+
+    template<std::size_t Generation>
+    auto get_generation() {
+        static_assert(Generation == 0);
+        return std::tie(_leaf, _tail_n, _tail_str, _tail_vec);
+    }
+
+    auto serde_fields() {
+        return std::tie(_leaf, _tail_n, _tail_str, _tail_vec);
+    }
+};
+
+std::string flatten(const iobuf& b) {
+    auto s = std::string(b.size_bytes(), '\0');
+    auto in = iobuf_const_parser{b};
+    in.consume_to(s.size(), s.data());
+    return s;
+}
+
+iobuf unflatten(const std::string& s) {
+    auto b = iobuf{};
+    b.append(s.data(), s.size());
+    return b;
+}
+
+// serde writes its size prefixes little-endian.
+serde::serde_size_t load_le(const std::string& s, std::size_t pos) {
+    auto v = serde::serde_size_t{};
+    for (auto i = 0U; i != sizeof(v); ++i) {
+        v |= static_cast<serde::serde_size_t>(
+               static_cast<unsigned char>(s[pos + i]))
+             << (8U * i);
+    }
+    return v;
+}
+
+void store_le(std::string& s, std::size_t pos, serde::serde_size_t v) {
+    for (auto i = 0U; i != sizeof(v); ++i) {
+        s[pos + i] = static_cast<char>((v >> (8U * i)) & 0xffU);
+    }
+}
+
+// Corrupts an encoding the way a bit flip on disk, a truncated write or a
+// version skew does. Growing a size prefix by a little is the mutation that
+// matters most: the overrun has to clear the end of the enclosing scope but
+// stay inside the buffer, so a wild value is much less interesting than a
+// slightly wrong one.
+void mutate(std::string& s, data_gen& gen) {
+    const auto rounds = 1U + gen.get<std::uint8_t>() % 3U;
+    for (auto r = 0U; r != rounds; ++r) {
+        if (s.empty()) {
+            return;
+        }
+        const auto op = gen.get<std::uint8_t>() % 5U;
+        auto pos = std::size_t{gen.get<std::uint32_t>() % s.size()};
+        if (op <= 1U && !size_prefix_offsets.empty()) {
+            pos = size_prefix_offsets
+              [gen.get<std::uint32_t>() % size_prefix_offsets.size()];
+        }
+        switch (op) {
+        case 0:
+        case 1:
+            if (pos + sizeof(serde::serde_size_t) <= s.size()) {
+                store_le(
+                  s, pos, load_le(s, pos) + 1U + gen.get<std::uint8_t>() % 32U);
+            }
+            break;
+        case 2:
+            s[pos] = static_cast<char>(gen.get<std::uint8_t>());
+            break;
+        case 3:
+            s.resize(pos);
+            break;
+        case 4:
+            s.push_back(static_cast<char>(gen.get<std::uint8_t>()));
+            break;
+        }
+    }
+}
+
+// Untrusted bytes may be rejected, but only in one of these ways. Anything else
+// - a bad_variant_access, a logic_error, a seastar exception - is the decoder
+// failing to handle input it is required to handle. Returning a value is fine;
+// what it must not do is return one having read a field from outside its scope,
+// which is what read_scoped() above traps on.
+template<typename T>
+void decode_untrusted(const std::string& encoded, const char* what) {
+    try {
+        auto decoded = serde::from_iobuf<T>(unflatten(encoded));
+        asm volatile("" ::"r"(&decoded) : "memory");
+    } catch (const serde::serde_exception&) {
+        // The decoder rejected the input, which is the contract.
+    } catch (const std::out_of_range&) {
+        // A read ran past the end of the physical iobuf.
+    } catch (const std::bad_alloc&) {
+        // A garbage length reached an allocation.
+    } catch (const std::length_error&) {
+        // Ditto, for a length past a container's max_size().
+    } catch (const std::exception& e) {
+        std::cout << what << ": unexpected exception: " << e.what() << "\n"
+                  << std::flush;
+        __builtin_trap();
+    }
+}
+
+// The untouched encoding has to decode cleanly and stay inside its scopes, or
+// the corrupted run proves nothing: a writer and reader that disagree would
+// look like a decoder that rejects everything.
+template<typename T>
+void decode_valid(const std::string& encoded) {
+    try {
+        auto decoded = serde::from_iobuf<T>(unflatten(encoded));
+        asm volatile("" ::"r"(&decoded) : "memory");
+    } catch (const std::exception& e) {
+        std::cout << "valid encoding rejected: " << e.what() << "\n"
+                  << std::flush;
+        __builtin_trap();
+    }
+}
+
+template<typename T>
+void fuzz_decode(data_gen gen) {
+    auto orig = T{};
+    init(orig, gen, std::make_index_sequence<1>());
+
+    size_prefix_offsets.clear();
+    const auto encoded = flatten(serde::to_iobuf(orig));
+
+    decode_valid<T>(encoded);
+
+    auto corrupted = encoded;
+    mutate(corrupted, gen);
+    decode_untrusted<T>(corrupted, "corrupted encoding");
+}
+
+template<typename... T>
+void fuzz_decode_all(type_list<T...>, data_gen gen) {
+    (fuzz_decode<T>(gen), ...);
+}
+
+// Decoding the fuzzer's bytes as they arrive, with no valid encoding underneath
+// them. The mutation pass only ever explores payloads that are nearly
+// well-formed, since it starts from something the writer produced; this one
+// starts from nothing, so it reaches the shapes a mutation of a valid encoding
+// will not reach - a version pair no writer emits, an envelope size that
+// disagrees with the fields inside it, a nesting depth the writer never
+// produces. libFuzzer's coverage feedback supplies the few header bytes needed
+// to get past read_header, and from there every reader is looking at lengths it
+// has no reason to trust.
+template<typename... T>
+void fuzz_decode_raw(type_list<T...>, const std::string& bytes) {
+    (decode_untrusted<T>(bytes, "random bytes"), ...);
+}
+
 void fuzz_serde(const uint8_t* data, size_t size) {
     constexpr const auto gen1 = std::make_index_sequence<1>();
 
@@ -225,6 +504,13 @@ void fuzz_serde(const uint8_t* data, size_t size) {
 
     test_version_upgrade(types_21{}, types_22{}, {data, size}, gen1);
     test_version_upgrade(types_22{}, types_21{}, {data, size}, gen1);
+
+    fuzz_decode<scoped_outer>({data, size});
+    fuzz_decode_all(types_21{}, {data, size});
+
+    const auto raw = std::string{reinterpret_cast<const char*>(data), size};
+    fuzz_decode_raw(type_list<scoped_outer>{}, raw);
+    fuzz_decode_raw(types_21{}, raw);
 }
 
 #if defined(MAIN)

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -1215,3 +1215,198 @@ SEASTAR_THREAD_TEST_CASE(pair_test) {
       {"one", 1}, {"two", 2}, {"three", 3}};
     BOOST_REQUIRE(serde_input(v) == v);
 }
+
+// ---------------------------------------------------------------------------
+// The scalar reader's bounds check against the end of the current serde scope.
+//
+// bytes_left_limit is the value bytes_left() is expected to have when the scope
+// ends, so a scalar read needs bytes_left() >= bytes_left_limit + sizeof(Type).
+// The tests below cover the case a size_t subtraction cannot: a preceding
+// variable-length read can leave bytes_left() *below* the limit, and
+// bytes_left() - bytes_left_limit wraps to near SIZE_MAX there, which is never
+// < sizeof(Type). The guard has to reject that, otherwise the read decodes
+// bytes belonging to the enclosing scope and every field after it comes from a
+// shifted offset.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+iobuf filler(size_t n) {
+    iobuf b;
+    const ss::sstring s(n, 'x');
+    b.append(s.data(), s.size());
+    return b;
+}
+
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(scalar_read_scope_bounds) {
+    const auto read_int32 = [](size_t bytes_left, size_t bytes_left_limit) {
+        auto in = iobuf_parser{filler(bytes_left)};
+        int32_t v = 0;
+        serde::read_nested(in, v, bytes_left_limit);
+    };
+
+    // Scope has exactly enough room for the read.
+    BOOST_CHECK_NO_THROW(read_int32(8, 4));
+    // Scope is one byte short.
+    BOOST_CHECK_THROW(read_int32(8, 5), serde::serde_exception);
+    // Parser is already 4 bytes past the end of the scope. The read must be
+    // rejected rather than allowed to take bytes from the enclosing scope.
+    BOOST_CHECK_THROW(read_int32(4, 8), serde::serde_exception);
+}
+
+// A nested envelope with a hand-written reader that forwards its own
+// h._bytes_left_limit to its fields. This is the shape of ~40 production call
+// sites (security::acl_binding_filter::serde_read, raft/types.cc,
+// cluster/controller_snapshot.cc, ...) and effectively the only way a nonzero
+// limit reaches a field read: serde/rw/envelope.h hands generated
+// serde_fields() types the *incoming* limit, so a tree of generated types keeps
+// the limit at the 0 that read<T>() seeds.
+struct scope_underrun_inner
+  : serde::envelope<
+      scope_underrun_inner,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    ss::sstring _str;
+    int32_t _n{0};
+
+    // Bytes added to _str's encoded length prefix beyond the string actually
+    // written, i.e. how far a reader of this encoding overruns. Not itself
+    // encoded; this is what a corrupt or version-skewed length prefix looks
+    // like on the wire.
+    serde::serde_size_t _lie{0};
+
+    void serde_write(iobuf& out) const {
+        serde::write<serde::serde_size_t>(
+          out, static_cast<serde::serde_size_t>(_str.size() + _lie));
+        out.append(_str.data(), _str.size());
+        serde::write(out, _n);
+    }
+
+    void serde_read(iobuf_parser& in, const serde::header& h) {
+        serde::read_nested(in, _str, h._bytes_left_limit);
+        serde::read_nested(in, _n, h._bytes_left_limit);
+    }
+};
+
+// The inner envelope is followed by 16 bytes of fields, so it does not end at
+// the end of the buffer and its h._bytes_left_limit is 16 rather than 0.
+struct scope_underrun_outer
+  : serde::envelope<
+      scope_underrun_outer,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    scope_underrun_inner _inner;
+    int64_t _tail_a{0};
+    int64_t _tail_b{0};
+
+    auto serde_fields() { return std::tie(_inner, _tail_a, _tail_b); }
+};
+
+namespace {
+
+iobuf encode_scope_underrun() {
+    auto obj = scope_underrun_outer{};
+    obj._inner._str = "abcdefgh";
+    obj._inner._n = 0x0a0b0c0d;
+    obj._inner._lie = 8;
+    obj._tail_a = 0x1122334455667788;
+    obj._tail_b = static_cast<int64_t>(0x99aabbccddeeff00);
+    return serde::to_iobuf(std::move(obj));
+}
+
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(scope_underrun_via_string_overrun) {
+    // Byte accounting, with serde_size_t == uint16_t under SERDE_TEST:
+    //
+    //   outer header                     4
+    //   inner header                     4
+    //   inner: _str length prefix        2   says 16, 8 bytes follow
+    //   inner: _str data                 8
+    //   inner: _n                        4
+    //   outer: _tail_a, _tail_b         16
+    //
+    // Reading the inner header leaves bytes_left() == 30 and
+    // h._bytes_left_limit == 30 - 14 == 16: the inner scope ends there. The
+    // _str read consumes 16 bytes instead of 8 and ends at bytes_left() == 12,
+    // four bytes past the end of the inner scope. The _n read that follows is
+    // the one that has to reject the payload, and the one a subtracting guard
+    // admits: 12 - 16 is near SIZE_MAX, never < 4. Admitting it decodes _str as
+    // "abcdefgh\x0d\x0c\x0b\x0a\x88\x77\x66\x55", _n as 0x11223344 taken from
+    // _tail_a, _tail_a from _tail_b, and never reaches _tail_b.
+    BOOST_CHECK_THROW(
+      serde::from_iobuf<scope_underrun_outer>(encode_scope_underrun()),
+      serde::serde_exception);
+}
+
+// Same mechanism reached through a container: neither vector.h nor map.h
+// re-checks the invariant between elements, so an element that overruns the
+// scope end corrupts every element after it.
+struct scope_underrun_vec_inner
+  : serde::envelope<
+      scope_underrun_vec_inner,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    std::vector<ss::sstring> _v;
+
+    // Added to element 0's encoded length prefix. See _lie above.
+    serde::serde_size_t _lie{0};
+
+    void serde_write(iobuf& out) const {
+        serde::write<serde::serde_size_t>(
+          out, static_cast<serde::serde_size_t>(_v.size()));
+        auto lie = _lie;
+        for (const auto& s : _v) {
+            serde::write<serde::serde_size_t>(
+              out, static_cast<serde::serde_size_t>(s.size() + lie));
+            out.append(s.data(), s.size());
+            lie = 0;
+        }
+    }
+
+    void serde_read(iobuf_parser& in, const serde::header& h) {
+        serde::read_nested(in, _v, h._bytes_left_limit);
+    }
+};
+
+struct scope_underrun_vec_outer
+  : serde::envelope<
+      scope_underrun_vec_outer,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    scope_underrun_vec_inner _inner;
+    int64_t _tail_a{0};
+    int64_t _tail_b{0};
+
+    auto serde_fields() { return std::tie(_inner, _tail_a, _tail_b); }
+};
+
+namespace {
+
+iobuf encode_scope_underrun_vec() {
+    auto obj = scope_underrun_vec_outer{};
+    obj._inner._v = {"aaaa", "bbbb"};
+    obj._inner._lie = 12;
+    // The low bytes are what element 1's length prefix is decoded from once
+    // element 0 has overrun; keeping them zero makes the wrong decode complete
+    // instead of running off the end of the buffer.
+    obj._tail_a = 0x0000334455667788;
+    obj._tail_b = static_cast<int64_t>(0x99aabbccddeeff00);
+    return serde::to_iobuf(std::move(obj));
+}
+
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(scope_underrun_via_vector_element_overrun) {
+    // Element 0's length prefix says 16 where 4 bytes follow, so it swallows
+    // element 1 whole plus six bytes of _tail_a and leaves bytes_left() == 10
+    // against a limit of 16. Element 1's own length prefix is then read through
+    // the wrapped guard: it decoded as 0 from _tail_a's bytes, giving
+    // _v == {"aaaa\x04\x00bbbb\x88\x77\x66\x55\x44\x33", ""} and _tail_a taken
+    // from _tail_b. The read must be rejected instead.
+    BOOST_CHECK_THROW(
+      serde::from_iobuf<scope_underrun_vec_outer>(encode_scope_underrun_vec()),
+      serde::serde_exception);
+}


### PR DESCRIPTION
The serde scalar reader's bounds check against the end of the current envelope
computed `in.bytes_left() - bytes_left_limit < sizeof(Type)` on two `size_t`
values, which assumes `bytes_left() >= bytes_left_limit`. Nothing enforces that.
`bytes_left()` counts to the end of the whole iobuf rather than to the end of the
current scope, and the readers in `sstring.h` and `iobuf.h` consume their entire
declared length without consulting the limit, so a length prefix that is too
large walks the parser past the scope end while leaving it inside the buffer. The
subtraction then wraps to near `SIZE_MAX`, which is never less than
`sizeof(Type)`, and the read is admitted in exactly the case the check exists to
reject.

The effect is a silent wrong decode rather than a rejection: a payload that
should raise `serde_exception` instead decodes the following fields from the
enclosing scope's bytes and returns successfully, so the failure surfaces later
and further from its cause. Memory safety is not affected, since
`io_iterator_consumer` still throws `std::out_of_range` on any read past the end
of the physical buffer.

Nonzero limits reach a field read almost exclusively through hand-written
`serde_read` bodies that forward `h._bytes_left_limit`, about 40 call sites
covering broker to broker RPC (raft, health monitor), the controller log and its
snapshots, cloud storage manifests and ACLs. Generated `serde_fields()` types
keep the limit at the 0 that `read<T>()` seeds, because `rw/envelope.h` forwards
the incoming limit to generated fields rather than the envelope's own.
`security::acl_binding_filter` is one verified reachable chain: its `serde_read`
forwards the limit, reads an `optional<ss::sstring>`, and then reads an optional
whose first act is a `bool`.

**First commit** rewrites the comparison as
`in.bytes_left() < bytes_left_limit + sizeof(Type)`. That stays a single
comparison, which matters because the function is force-inlined at every scalar
read site, and it also rejects a parser already past the scope end. It adds
`bytes_left_limit` to the exception message, which the message needed and
omitted, plus three tests: one pinning the boundary at the reader, and two
reproducing the overrun end to end, through a following scalar field and through
a following vector element.

**Second commit** is a distinct defect, found by the new fuzzing below rather
than by reading. The vector, set and map readers reserved capacity for the
element count read off the wire before reading any element, so a corrupt size
prefix became an allocation of whatever size the prefix asked for: a two byte
input requested 109 GiB. The reservation is now capped at the bytes left in the
parser, since encoding an element always costs at least one byte. Valid input is
unaffected, and the element loop still rejects the input when the bytes run out.

**Third commit** addresses why none of this was caught. The serde fuzz target
only round-tripped, so the decoder only ever saw well-formed output of its own
writer and no malformed size prefix was ever tried. Its generated structs are
also all `serde_fields()` envelopes, so `bytes_left_limit` stayed 0 and the
bounds guards were never asked about a real scope end. It adds two decode modes,
one that mutates a valid encoding with the size prefixes it recorded while
writing as the target, and one that decodes the raw fuzz input so it can reach
shapes the writer never produces. Both require the decoder to either decode the
input or reject it with `serde_exception`, `out_of_range`, `bad_alloc` or
`length_error`. The types they decode forward their own `h._bytes_left_limit` and
check the scope invariant around each field read, trapping when a read
*completes* from beyond the scope end. Reverting the first commit makes the fuzz
target fail in under a second; with it in place the target runs clean.

Verification: the three new tests fail before the fix and pass after it, all
serde tests pass, every target under `//src/v/...` builds, and a 20 minute
coverage-guided run of 482,976 executions found nothing further.

One note for reviewers, applying to fuzzing here generally rather than to this
change: nothing in the repo passes `--config=fuzz`, which is what adds the
`-fsanitize=fuzzer-no-link` copt that libFuzzer needs in order to guide itself.
The rule only puts `-fsanitize=fuzzer` in `linkopts`, so wherever CI runs these
targets they run blind, as `.bazelrc` notes. The new modes still function there,
but explore much less, and the libFuzzer args added here (`-max_len`,
`-len_control`, without which the effective input length stays near 20 bytes)
matter mainly for guided runs.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none