### PR TITLE
[CORE-17063] - security/audit: report misconfigured auth from client init

### DIFF
--- a/src/v/security/audit/client.cc
+++ b/src/v/security/audit/client.cc
@@ -25,8 +25,12 @@
 #include "security/authorizer.h"
 #include "utils/retry.h"
 
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
+
 #include <algorithm>
 #include <chrono>
+#include <optional>
 
 namespace security::audit {
 
@@ -263,6 +267,27 @@ public:
     }
     ss::future<> client_shutdown() final { co_await _client.stop(); }
     ss::future<> do_configure() final {
+        // Set _misconfigured on a failure from any configuration step. Only
+        // create_internal_topic() reports through the kafka client's
+        // mitigate_error(), and it runs only while the local topic table has
+        // no audit topic.
+        auto fut = co_await ss::coroutine::as_future(configure_client());
+        if (fut.failed()) {
+            auto eptr = fut.get_exception();
+            if (const auto errc = misconfigured_auth_error(eptr)) {
+                co_await update_status(*errc);
+            }
+            co_await ss::coroutine::return_exception_ptr(std::move(eptr));
+        }
+        // Every step succeeded, so the authorization works. Clear a flag
+        // that an earlier attempt set.
+        co_await update_status(kafka::error_code::none);
+    }
+
+private:
+    kafka_sink_impl* sink();
+
+    ss::future<> configure_client() {
         co_await set_client_credentials();
         // Propagate the audit principal's credential to every broker up
         // front (best effort). Previously propagation relied on
@@ -285,11 +310,30 @@ public:
         _client.set_max_retries(size_t{5});
     }
 
-private:
-    kafka_sink_impl* sink();
-
     auth_misconfigured_t _misconfigured{auth_misconfigured_t::no};
     kafka::client::client _client;
+
+    /// The error code in `eptr`, when it says authorization is misconfigured.
+    static std::optional<kafka::error_code>
+    misconfigured_auth_error(const std::exception_ptr& eptr) {
+        try {
+            std::rethrow_exception(eptr);
+        } catch (const kafka::exception_base& ex) {
+            if (indicates_misconfigured_auth(ex.error)) {
+                return ex.error;
+            }
+        } catch (...) {
+        }
+        return std::nullopt;
+    }
+
+    /// illegal_sasl_state means a listener rejects the audit client's SASL
+    /// handshake. topic_authorization_failed means the audit principal lacks
+    /// ACLs on the audit topic. Both need an operator to fix the cluster.
+    static bool indicates_misconfigured_auth(kafka::error_code errc) {
+        return errc == kafka::error_code::illegal_sasl_state
+               || errc == kafka::error_code::topic_authorization_failed;
+    }
 
     ss::future<> update_status(kafka::error_code errc);
     ss::future<> do_update_status(auth_misconfigured_t);
@@ -851,23 +895,12 @@ kafka_client_impl::do_update_status(auth_misconfigured_t misconfigured) {
 
 ss::future<> kafka_client_impl::update_status(kafka::error_code errc) {
     /// If the status changed to erroneous from anything else.
-    /// topic_authorization_failed means the audit principal's ACL bindings
-    /// are gone (or the exists-skip in set_auditing_permissions read a
-    /// stale positive); treat it like illegal_sasl_state so the condition
-    /// degrades loudly through _misconfigured instead of silently dropping
-    /// batches.
-    if (
-      (errc == kafka::error_code::illegal_sasl_state
-       || errc == kafka::error_code::topic_authorization_failed)
-      && !_misconfigured) {
+    if (indicates_misconfigured_auth(errc) && !_misconfigured) {
         return do_update_status(auth_misconfigured_t::yes);
     }
 
-    constexpr auto failed_codes = std::to_array(
-      {kafka::error_code::illegal_sasl_state,
-       kafka::error_code::topic_authorization_failed,
-       kafka::error_code::broker_not_available});
-    const bool success = !std::ranges::contains(failed_codes, errc);
+    const bool success = !indicates_misconfigured_auth(errc)
+                         && errc != kafka::error_code::broker_not_available;
     if (success && _misconfigured) {
         /// The status changed from erroneous to anything else
         return do_update_status(auth_misconfigured_t::no);


### PR DESCRIPTION
Fixes a regression introduced in #31411. The test mentioned below has been flaking hard in CI.

**Context**: #31411 changed the audit manager initialization to skip topic creation if the topic already exists. This is fine, but, in the event of misconfigured authorization, we were relying on a _failed_ creation step to trigger the kclients mitigate_error path, which in turn sets a _misconfigured flag on the audit_client. This flag is used by the audit manager to short circuit the event queues when authZ is borked. If authZ is misconfigured, the client.connect() operation at the end of the audit client initialization step would still fail, but this call _does not_ trigger mitigate_error in the kclient error handling path, instead just throwing, so after #31411, if the audit topic is already created at startup, we have no way of detecting misconfigured authZ in the manager.

_misconfigured was set only when create_internal_topic() failed, because that is the one configuration step whose errors reach the kafka client's mitigate_error(). That step runs only when the local topic table has no audit topic yet, so reporting a misconfigured authorization raced with topic table recovery at startup. Every other step, _client.connect() included, reports its error to do_configure().

Set the flag in do_configure() when any configuration step fails, and clear it there once every step succeeds. While the flag is set, audit_log_manager warns on every audit event and applies audit_log_reject_policy to it.

Covered by audit_log_test.test_no_auth_enabled, which waits for the rejection warning after removing authentication from a listener.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

### Bug Fixes

* Fixes a race condition in audit log startup where we could fail to detect misconfigured authorization settings.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
