### PR TITLE
config: Lower default fallocate step

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1536,7 +1536,7 @@ configuration::configuration(ctor_key)
       {.needs_restart = needs_restart::no,
        .example = "32768",
        .visibility = visibility::tunable},
-      32_MiB,
+      2_MiB,
       storage::validate_fallocation_step)
   , storage_target_replay_bytes(
       *this,


### PR DESCRIPTION
On multiple instances we have now seen heavy XFS fragmentation caused
primarily by small segments as a result of compaction.

This results in XFS extent distributions such as this one:

```
xfs_db -r /mnt/foo -c "freesp -s"
   from      to extents  blocks    pct
      1       1  219159  219159   2.95
      2       3   73640  167835   2.26
      4       7   63231  257920   3.47
      8      15  493848 6637298  89.21
     16      31    9623  157998   2.12
     32      63       3     123   0.00
total free extents 859504
total free blocks 7440333
average free extent size 8.65654
```

The average extent here is just 8 * 4096 bytes so fairly small. Together
with our default fallocate step size of 32MiB this means that when
fallocating XFS has to do a long search to find enough extents. This
basically works by doing repeated finds until enough extents are found
to fulfill the requested 32MiB (these don't have to be contiguous).

We have seen fallocate times up into many hundreds of milliseconds:

```
172.433 (793.406 ms): syscall-8/3970399 fallocate(fd: 748, mode: 17, len: 33554432)
145.233 (820.742 ms): syscall-3/3970403 fallocate(fd: 919, mode: 17, len: 33554432)
180.920 (785.227 ms): syscall-12/3970407 fallocate(fd: 626, mode: 17, len: 33554432)
427.525 (541.225 ms): syscall-11/3970400 fallocate(fd: 614, mode: 17, len: 33554432)
```

fallocates run from the syscall thread. This causes a problems in two
ways. First, any write that is queued logically from the application
level after the fallocate will get massively delayed. Second, any other
unrelated write that got punted to the syscall thread for fallback
reasons will also suffer this latency.

This latency results in both bad Kafka latency and in the worst case can
lead to heartbeat timeouts (which will result in leadership transfers,
new segments, more fallocates and hence a cycle of death).

To avoid these stalls we lower the default falloc step size to 2 MiB.
This has shown to work well in production as well as in manual testing.

Fragmentation like above is easy to reproduce using the XFS punch-holes
script from TCI.

Note that from a manual microbenchmark test it seems like the time it
takes to fallocate scales linearly. fallocate of (N * 10) takes about the
same amount of time as 10 * fallocate(N). So the improvements seem to be
coming from avoiding traditional stop-the-world pauses and pacing via
smaller stalls.

In the good case this seems to have very little to no difference on
performance. A BLB report using an even lower 1MiB step size can be
found here:
https://perf-team-public.s3.us-west-2.amazonaws.com/reports/fallocate.html

An alternative approach would have been to switch from `fallocate` to
using XFS extent size hints. Extent size hints make the larger
allocation happen only at write time. At the same time, it's only a
hint. If only less contiguous space is available then only that amount
will be pre-allocated.

This has a few consequences which make it less appropriate for our usage
or at least could have many hidden consequences:

 - Allocation only happens at write time: This delays disk usage.
   So running out of disk is only noticed later. While this could be a
   pro it's probably more a con for being less predictable.
 - The actual fallocation step size is adaptive in redpanda: fallocation
   step behaviour is adaptive depending on remaining disk usage and
   partition count. Because a just created segment won't allocate any
   space with the extent size hint this means that the adaptive logic
   won't know about live segments until after those start to actually
   use disk. Further, the hinted size can't be changed if extents with
   other sizes exist for a file.
 - We do somewhat want batching in fallocate: Even under fragmentation
   we don't just want to preallocate 8KiB or similar (as might be the
   case with only using the hint). This would cause many many syscall
   thread roundtrips which are worse than doing a medium sized batched
   pre-allocation to amortize the cost across follow-up writes.

The last point could potentially be worked around with by a combination
of first doing a (larger) hinted write followed by fallocating a smaller
chunk and repeating this pattern whenever the multiple of fallocate step
size reaches the hint size. I haven't tested this though as it doesn't
really seem worth it given that the smaller default step size doesn't
seem to have any drawbacks.
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

