### PR TITLE
[v26.2.x] rpk: sql debug bundle fixes — metrics layout, per-node queries, default CPU profile, k8s resources, parallel collection

### DIFF
--- a/src/go/rpk/pkg/cli/sql/debug/bundle/BUILD
+++ b/src/go/rpk/pkg/cli/sql/debug/bundle/BUILD
@@ -6,6 +6,7 @@ go_library(
         "bundle.go",
         "client.go",
         "collect.go",
+        "collect_k8s.go",
         "messages.go",
     ],
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/sql/debug/bundle",
@@ -18,5 +19,7 @@ go_library(
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_pflag//:pflag",
+        "@io_k8s_client_go//kubernetes",
+        "@io_k8s_client_go//rest",
     ],
 )

--- a/src/go/rpk/pkg/cli/sql/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/sql/debug/bundle/bundle.go
@@ -121,7 +121,7 @@ func (c *bundleFlags) install(f *pflag.FlagSet) {
 	f.StringVar(&c.auth.token, "token", "", "Bearer token (mutually exclusive with --user/--password)")
 	f.StringVar(&c.sqlText, "include-sql-text", "masked", "SQL text in query artifacts: masked|raw")
 	f.BoolVar(&c.vmstat, "include-vmstat", false, "Include vmstat in host probes (~1s slower)")
-	f.UintVar(&c.cpuSeconds, "cpu-profile-seconds", 0, "Collect a CPU profile of this duration per node (0 = skip)")
+	f.UintVar(&c.cpuSeconds, "cpu-profile-seconds", 30, "Collect a CPU profile of this duration per node (0 = skip)")
 	f.DurationVar(&c.logSince, "log-since", 0, "Collect log lines newer than this (0 = server default window)")
 	f.Uint64Var(&c.logSizeLim, "log-size-limit", 0, "Max log bytes per node (0 = server default)")
 	f.Uint16Var(&c.metricsPort, "metrics-port", 8080, "Per-node Prometheus metrics port")
@@ -139,6 +139,11 @@ func (c *bundleFlags) options(fs afero.Fs) (Options, error) {
 
 	if c.metricsSamples < 1 {
 		return Options{}, fmt.Errorf("--metrics-samples must be > 0, got %d", c.metricsSamples)
+	}
+
+	// The profile RPC blocks for the whole profiling duration.
+	if profile := time.Duration(c.cpuSeconds) * time.Second; profile >= c.timeout {
+		return Options{}, fmt.Errorf("--cpu-profile-seconds (%v) must be below --timeout (%v); raise --timeout or lower the profile duration", profile, c.timeout)
 	}
 
 	var tlsCfg *tls.Config

--- a/src/go/rpk/pkg/cli/sql/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/sql/debug/bundle/bundle.go
@@ -52,18 +52,20 @@ type authFlags struct {
 }
 
 type bundleFlags struct {
-	adminHosts  []string
-	output      string
-	uploadURL   string
-	tls         tlsFlags
-	auth        authFlags
-	sqlText     string
-	vmstat      bool
-	cpuSeconds  uint
-	logSince    time.Duration
-	logSizeLim  uint64
-	metricsPort uint16
-	timeout     time.Duration
+	adminHosts      []string
+	output          string
+	uploadURL       string
+	tls             tlsFlags
+	auth            authFlags
+	sqlText         string
+	vmstat          bool
+	cpuSeconds      uint
+	logSince        time.Duration
+	logSizeLim      uint64
+	metricsPort     uint16
+	metricsSamples  int
+	metricsInterval time.Duration
+	timeout         time.Duration
 }
 
 func NewCommand(fs afero.Fs, _ *config.Params) *cobra.Command {
@@ -122,7 +124,9 @@ func (c *bundleFlags) install(f *pflag.FlagSet) {
 	f.UintVar(&c.cpuSeconds, "cpu-profile-seconds", 0, "Collect a CPU profile of this duration per node (0 = skip)")
 	f.DurationVar(&c.logSince, "log-since", 0, "Collect log lines newer than this (0 = server default window)")
 	f.Uint64Var(&c.logSizeLim, "log-size-limit", 0, "Max log bytes per node (0 = server default)")
-	f.Uint16Var(&c.metricsPort, "metrics-port", 8080, "Per-node Prometheus metrics port (scraped twice ~1s apart)")
+	f.Uint16Var(&c.metricsPort, "metrics-port", 8080, "Per-node Prometheus metrics port")
+	f.IntVar(&c.metricsSamples, "metrics-samples", 2, "Number of metrics samples to take per node (at the interval of --metrics-interval). Must be > 0")
+	f.DurationVar(&c.metricsInterval, "metrics-interval", 10*time.Second, "Interval between metrics samples")
 	f.DurationVar(&c.timeout, "timeout", 60*time.Second, "Per-RPC timeout")
 }
 
@@ -131,6 +135,10 @@ func (c *bundleFlags) options(fs afero.Fs) (Options, error) {
 	sqlMode, err := sqlTextMode(c.sqlText)
 	if err != nil {
 		return Options{}, err
+	}
+
+	if c.metricsSamples < 1 {
+		return Options{}, fmt.Errorf("--metrics-samples must be > 0, got %d", c.metricsSamples)
 	}
 
 	var tlsCfg *tls.Config
@@ -158,6 +166,8 @@ func (c *bundleFlags) options(fs afero.Fs) (Options, error) {
 		LogSinceUnixMs:    logSinceMs,
 		LogSizeLimitBytes: c.logSizeLim,
 		MetricsPort:       c.metricsPort,
+		MetricsSamples:    c.metricsSamples,
+		MetricsInterval:   c.metricsInterval,
 		ToolVersion:       "rpk",
 	}, nil
 }

--- a/src/go/rpk/pkg/cli/sql/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/sql/debug/bundle/bundle.go
@@ -65,6 +65,7 @@ type bundleFlags struct {
 	metricsPort     uint16
 	metricsSamples  int
 	metricsInterval time.Duration
+	namespace       string
 	timeout         time.Duration
 }
 
@@ -127,6 +128,7 @@ func (c *bundleFlags) install(f *pflag.FlagSet) {
 	f.Uint16Var(&c.metricsPort, "metrics-port", 8080, "Per-node Prometheus metrics port")
 	f.IntVar(&c.metricsSamples, "metrics-samples", 2, "Number of metrics samples to take per node (at the interval of --metrics-interval). Must be > 0")
 	f.DurationVar(&c.metricsInterval, "metrics-interval", 10*time.Second, "Interval between metrics samples")
+	f.StringVarP(&c.namespace, "namespace", "n", "", "Kubernetes namespace to collect resources from (K8s only; default: the pod's own namespace)")
 	f.DurationVar(&c.timeout, "timeout", 60*time.Second, "Per-RPC timeout")
 }
 
@@ -173,6 +175,7 @@ func (c *bundleFlags) options(fs afero.Fs) (Options, error) {
 		MetricsPort:       c.metricsPort,
 		MetricsSamples:    c.metricsSamples,
 		MetricsInterval:   c.metricsInterval,
+		Namespace:         c.namespace,
 		ToolVersion:       "rpk",
 	}, nil
 }

--- a/src/go/rpk/pkg/cli/sql/debug/bundle/collect.go
+++ b/src/go/rpk/pkg/cli/sql/debug/bundle/collect.go
@@ -200,17 +200,18 @@ func (b *bundle) nodeCalls(ctx context.Context, endpoint string) {
 			b.add(dir+"cpu_profile.pprof.gz", cp.PprofGzip)
 		}
 	}
-	b.scrapeMetrics(ctx, endpoint, dir)
+	b.scrapeMetrics(ctx, endpoint)
 }
 
 // scrapeMetrics pulls the node's plain-HTTP Prometheus /metrics endpoint
 // MetricsSamples times, MetricsInterval apart (no TLS or auth on that port).
-func (b *bundle) scrapeMetrics(ctx context.Context, node, dir string) {
+func (b *bundle) scrapeMetrics(ctx context.Context, node string) {
 	host := node
 	if i := strings.LastIndex(node, ":"); i >= 0 {
 		host = node[:i]
 	}
 	url := fmt.Sprintf("http://%s:%d/metrics", host, b.opts.MetricsPort)
+	dir := fmt.Sprintf("%s/metrics/%s/", bundleRoot, debugbundle.SanitizeName(node))
 
 	for i := 0; i < b.opts.MetricsSamples; i++ {
 		if i > 0 {

--- a/src/go/rpk/pkg/cli/sql/debug/bundle/collect.go
+++ b/src/go/rpk/pkg/cli/sql/debug/bundle/collect.go
@@ -47,6 +47,7 @@ type Options struct {
 	MetricsPort       uint16
 	MetricsSamples    int
 	MetricsInterval   time.Duration
+	Namespace         string
 	ToolVersion       string
 }
 
@@ -54,7 +55,7 @@ type Options struct {
 type collectionResult struct {
 	Node      string `json:"node"`
 	RPC       string `json:"rpc"`
-	Status    string `json:"status"` // "ok" | "error"
+	Status    string `json:"status"` // "ok" | "error" | "skipped"
 	ElapsedMs int64  `json:"elapsed_ms"`
 	Error     string `json:"error,omitempty"`
 }
@@ -112,6 +113,7 @@ func (b *bundle) collect(ctx context.Context) {
 	for _, ep := range endpoints {
 		b.nodeCalls(ctx, ep)
 	}
+	b.k8sResources(ctx)
 }
 
 // discover resolves the node list from the first seed that answers

--- a/src/go/rpk/pkg/cli/sql/debug/bundle/collect.go
+++ b/src/go/rpk/pkg/cli/sql/debug/bundle/collect.go
@@ -45,6 +45,8 @@ type Options struct {
 	LogSinceUnixMs    int64
 	LogSizeLimitBytes uint64
 	MetricsPort       uint16
+	MetricsSamples    int
+	MetricsInterval   time.Duration
 	ToolVersion       string
 }
 
@@ -201,10 +203,8 @@ func (b *bundle) nodeCalls(ctx context.Context, endpoint string) {
 	b.scrapeMetrics(ctx, endpoint, dir)
 }
 
-// scrapeMetrics pulls the node's Prometheus /metrics endpoint twice ~1s apart so
-// the bundle carries a short time series for rate/delta analysis. Metrics are
-// served by a separate plain-HTTP server (config `metrics.port`), not the admin
-// API, so this uses http:// on that port and neither TLS nor auth.
+// scrapeMetrics pulls the node's plain-HTTP Prometheus /metrics endpoint
+// MetricsSamples times, MetricsInterval apart (no TLS or auth on that port).
 func (b *bundle) scrapeMetrics(ctx context.Context, node, dir string) {
 	host := node
 	if i := strings.LastIndex(node, ":"); i >= 0 {
@@ -212,14 +212,18 @@ func (b *bundle) scrapeMetrics(ctx context.Context, node, dir string) {
 	}
 	url := fmt.Sprintf("http://%s:%d/metrics", host, b.opts.MetricsPort)
 
-	scrape := func(suffix string) {
+	for i := 0; i < b.opts.MetricsSamples; i++ {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(b.opts.MetricsInterval):
+			}
+		}
 		start := time.Now()
-		err := b.httpGetToFile(ctx, url, dir+"metrics_"+suffix+".txt")
+		err := b.httpGetToFile(ctx, url, fmt.Sprintf("%smetrics_t%d.txt", dir, i))
 		b.record(node, "GET /metrics", start, err)
 	}
-	scrape("t0")
-	time.Sleep(time.Second)
-	scrape("t1")
 }
 
 // httpGetToFile GETs url and writes the body to name in the bundle. Non-200 is an

--- a/src/go/rpk/pkg/cli/sql/debug/bundle/collect.go
+++ b/src/go/rpk/pkg/cli/sql/debug/bundle/collect.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/debug/debugbundle"
@@ -88,9 +89,12 @@ func writeBundle(ctx context.Context, out io.Writer, opts Options) error {
 }
 
 type bundle struct {
-	zw       *zip.Writer
-	opts     Options
-	hc       *http.Client
+	zw   *zip.Writer
+	opts Options
+	hc   *http.Client
+
+	// mu guards zw, results, errs, and versions during the per-node fan-out.
+	mu       sync.Mutex
 	results  []collectionResult
 	errs     []string
 	versions map[string]string // endpoint -> version
@@ -110,9 +114,15 @@ func (b *bundle) client(endpoint string) *Client {
 func (b *bundle) collect(ctx context.Context) {
 	endpoints, clusterCl := b.discover(ctx)
 	b.clusterCalls(ctx, clusterCl)
+	var wg sync.WaitGroup
 	for _, ep := range endpoints {
-		b.nodeCalls(ctx, ep)
+		wg.Add(1)
+		go func(ep string) {
+			defer wg.Done()
+			b.nodeCalls(ctx, ep)
+		}(ep)
 	}
+	wg.Wait()
 	b.k8sResources(ctx)
 }
 
@@ -173,7 +183,9 @@ func (b *bundle) nodeCalls(ctx context.Context, endpoint string) {
 	if raw, ok := b.grabJSON(ctx, cl, endpoint, "GetVersion", emptyRequest, dir+"version.json"); ok {
 		var v getVersionResponse
 		if json.Unmarshal(raw, &v) == nil {
+			b.mu.Lock()
 			b.versions[endpoint] = v.Version
+			b.mu.Unlock()
 		}
 	}
 	// config.yaml is per-node (env overrides, host_name, ports differ), so collect
@@ -365,6 +377,8 @@ func (b *bundle) call(ctx context.Context, cl *Client, node, method string, req,
 
 func (b *bundle) record(node, rpc string, start time.Time, err error) {
 	res := collectionResult{Node: node, RPC: rpc, Status: "ok", ElapsedMs: time.Since(start).Milliseconds()}
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if err != nil {
 		res.Status = "error"
 		res.Error = err.Error()
@@ -374,6 +388,8 @@ func (b *bundle) record(node, rpc string, start time.Time, err error) {
 }
 
 func (b *bundle) add(name string, data []byte) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	f, err := b.zw.Create(name)
 	if err != nil {
 		b.errs = append(b.errs, fmt.Sprintf("zip create %s: %v", name, err))

--- a/src/go/rpk/pkg/cli/sql/debug/bundle/collect.go
+++ b/src/go/rpk/pkg/cli/sql/debug/bundle/collect.go
@@ -154,8 +154,6 @@ func (b *bundle) clusterCalls(ctx context.Context, cl *Client) {
 	dir := bundleRoot + "/cluster/"
 
 	b.grabJSON(ctx, cl, node, "GetOxlaHomeListing", emptyRequest, dir+"redpanda_sql_home_listing.json")
-	b.grabJSON(ctx, cl, node, "GetRecentQueries",
-		getRecentQueriesRequest{IncludeSQLText: b.opts.SQLTextMode}, dir+"recent_queries.json")
 
 	if head := (getCatalogHeadResponse{}); b.call(ctx, cl, node, "GetCatalogHead", emptyRequest, &head) {
 		b.add(dir+"catalog_head.pb", head.CatalogHead)
@@ -183,6 +181,8 @@ func (b *bundle) nodeCalls(ctx context.Context, endpoint string) {
 	}
 	b.grabJSON(ctx, cl, endpoint, "GetActiveQueries",
 		getActiveQueriesRequest{IncludeSQLText: b.opts.SQLTextMode}, dir+"active_queries.json")
+	b.grabJSON(ctx, cl, endpoint, "GetRecentQueries",
+		getRecentQueriesRequest{IncludeSQLText: b.opts.SQLTextMode}, dir+"recent_queries.json")
 
 	b.resourceUsage(ctx, cl, endpoint, dir)
 

--- a/src/go/rpk/pkg/cli/sql/debug/bundle/collect_k8s.go
+++ b/src/go/rpk/pkg/cli/sql/debug/bundle/collect_k8s.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package bundle
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// k8sResources dumps the namespace's core-v1 resources under a kubernetes/
+// subtree, one JSON file per resource kind, mirroring what `rpk debug bundle`
+// collects. Collection runs only when the process is inside a Kubernetes pod
+// (in-cluster config resolves); anywhere else it is skipped silently, so
+// workstation runs against a remote cluster stay k8s-free.
+func (b *bundle) k8sResources(ctx context.Context) {
+	k8sCfg, err := rest.InClusterConfig()
+	if err != nil {
+		b.results = append(b.results, collectionResult{
+			Node:   "k8s",
+			RPC:    "resources",
+			Status: "skipped",
+			Error:  fmt.Sprintf("kubernetes unavailable: %v", err),
+		})
+		return
+	}
+	// One request per resource kind; raise the burst to avoid throttling.
+	k8sCfg.Burst = 30
+	clientset, err := kubernetes.NewForConfig(k8sCfg)
+	if err != nil {
+		b.errs = append(b.errs, fmt.Sprintf("[k8s] unable to create kubernetes client: %v", err))
+		return
+	}
+
+	namespace := b.namespace()
+	restInterface := clientset.CoreV1().RESTClient()
+	for _, resource := range []string{
+		"configmaps",
+		"endpoints",
+		"events",
+		"limitranges",
+		"persistentvolumeclaims",
+		"pods",
+		"replicationcontrollers",
+		"resourcequotas",
+		"serviceaccounts",
+		"services",
+	} {
+		start := time.Now()
+		raw, err := restInterface.Get().Namespace(namespace).Resource(resource).Do(ctx).Raw()
+		if err != nil {
+			// client-go can hide the server's Status message; prefer the body's.
+			var status struct {
+				Message string `json:"message"`
+			}
+			if json.Unmarshal(raw, &status) == nil && status.Message != "" {
+				err = errors.New(status.Message)
+			}
+		}
+		b.record("k8s", resource, start, err)
+		if err == nil {
+			b.addJSON(fmt.Sprintf("%s/kubernetes/%s.json", bundleRoot, resource), raw)
+		}
+	}
+}
+
+// namespace resolves the collection namespace: --namespace, then $NAMESPACE,
+// then the pod's service-account namespace, then "default".
+func (b *bundle) namespace() string {
+	if b.opts.Namespace != "" {
+		return b.opts.Namespace
+	}
+	if ns := os.Getenv("NAMESPACE"); ns != "" {
+		return ns
+	}
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		return strings.TrimSpace(string(data))
+	}
+	return "default"
+}


### PR DESCRIPTION
Backport of #31400 to `v26.2.x`.

The initial `rpk sql debug bundle` command (#31344) was already backported to
`v26.2.x` as 16d555532b. This brings over the six follow-up commits that were
not, so the branch matches `dev`:

- `rpk: make sql debug bundle metrics sampling configurable`
- `rpk: move sql debug bundle metrics under a metrics/ subtree`
- `rpk: collect sql debug bundle recent queries per node`
- `rpk: collect sql debug bundle CPU profiles by default`
- `rpk: collect kubernetes resources in the sql debug bundle`
- `rpk: parallelize sql debug bundle node collection`

All six cherry-picked cleanly with no conflicts and no manual edits. The
`src/go/rpk/pkg/cli/sql` tree on this branch is now byte-identical to `dev`.

## Backport checks

- `go build ./...` and `go vet ./pkg/cli/sql/...` pass in `src/go/rpk`.
- The k8s collection commit adds `@io_k8s_client_go//kubernetes` and
  `//rest` bazel deps; both are already used by `rpk debug bundle` on
  `v26.2.x` and `k8s.io/client-go v0.35.3` is in `go.mod`, so no dependency
  changes were needed.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v26.2.x

## Release Notes

- none
