### PR TITLE
docs: Move coding guidelines from the cupboard into redpanda

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ Follow the guidelines provided in `proto/redpanda/README.md` for basic Protobuf 
 
 Check that these guidelines are followed for new code.
 
+- Write [scalable code](docs/writing-scalable-and-high-performance-code.md).
 - Do not declare new `operator<<(ostream& os, type)` overloads, instead prefer to use a `format_to` member function inside `type` as described in
 src/v/base/format_to.h.
 - Prefer using latest C++ features (C++23).
@@ -158,6 +159,11 @@ src/v/base/format_to.h.
 - Do not call the `get_exception` method on a future within a logging or
   assertion statement (e.g. `vlog(..., fut.get_exception(), ...)`). Instead,
   assign the return value of `get_exception` in a variable and pass the variable.
+
+### Coroutines
+
+Follow [coroutines best practices](docs/writing-high-performance-coroutine-code.md) when using
+coroutines.
 
 #### Lambda coroutines, coroutine argument capture, and deducing this
 

--- a/docs/writing-high-performance-coroutine-code.md
+++ b/docs/writing-high-performance-coroutine-code.md
@@ -1,0 +1,219 @@
+# TLDR:
+
+ - Write sync code if possible
+ - Use coroutines over continuations
+ - Don't overoptimize for allocs in microbenchmarks unless the per coroutine
+   work is very low, e.g.: when parsing fields on a per record level
+
+# Writing high performance coroutine code
+
+## Keep coroutine chains intact aka. just use coroutines
+
+HALO (heap allocation elision optimization) can merge nested coroutine frames
+into the parent frame. This works best if all code is coroutines. coroutine ->
+continuation -> coroutine -> continuation doesn't allow for frame merging. Note
+that there is no magical optimizer that will help with this. 
+
+**Do:** Keep async call chains coroutine based all the way down.
+
+```cpp
+ss::future<> a() {
+  co_await b();
+}
+
+ss::future<> b() {
+  co_await c();
+}
+```
+
+**Don't:** Mix coroutines and continuations 
+
+```cpp
+ss::future<> a() {
+    co_await b().then(...)
+}
+```
+
+## Await futures directly
+
+If the returned future of a coroutine is not needed for async purposes
+`co_await` a coroutine directly. Otherwise HALO won't apply.
+
+**Do:** 
+
+```cpp
+co_await foo();
+```
+
+**Don't:** 
+
+```cpp
+auto f = foo();
+co_await std::move(f);
+```
+
+## Pass futures directly
+
+`when_all`, `when_all_succeed`, `coroutine::as_future`, `coroutine::try_future`
+and `coroutine::without_preemption_check` are HALO aware.
+
+**Do:** Pass newly created coroutine futures directly to these wrappers.
+
+```cpp
+co_await ss::when_all(a(), b());
+co_await ss::coroutine::as_future(c());
+```
+
+**Don't:** Store the child future first when it can be passed directly.
+
+```cpp
+auto f = c();
+co_await ss::coroutine::as_future(std::move(f));
+```
+
+## Be aware of scheduling semantics
+
+The biggest functional and also performance difference between continuations and
+coroutines is their scheduling semantics.
+
+`co_await` is a preemption point.
+
+`.then` doesn't perform the same preemption check and future returning callbacks
+use Seastar's urgent scheduling (in contrast to value returning callbacks that
+use normal append-to-end-of-taskqueue scheduling).
+
+**Do:** Make an intentional choice when replacing continuation code.
+
+```cpp
+co_await ss::coroutine::without_preemption_check(work());
+update();
+```
+
+**Don't:** Assume a direct rewrite is scheduling equivalent. This can change
+lock hold time, batching and latency.
+
+```cpp
+future<> work();
+
+future<> cont() {
+    return get_lock().then([] {  return work(); });
+}
+
+// not-equivalent
+future<> coro() {
+    auto lock = co_await get_lock();
+    co_await work();
+}
+```
+
+The coroutine version can potentially suspend twice, once just after acquiring
+the lock and a second time before calling `work`.
+
+The continuation version never suspends under lock. This isn't just about
+correctness (most of the time it's fine to suspend under the lock) but also a
+performance one.
+
+Note that neither is directly better or worse. Suspending under the lock is
+likely bad for latency but can cause batching in other parts of the system. This
+is in all likelihood good for throughput and reduced reactor util. If you want
+batching it's best to implement an explicit batching pattern that doesn't
+rely on scheduling semantics.
+
+## Don't overoptimize for allocations
+
+Don't obsess over allocations related to coroutines and continuations. They only
+matter if the per coroutine/continuation work is very small. There are very few
+cases in Redpanda that fit this pattern, examples are: field parsing in
+iceberg/protobuf/json/avro, per field compression handling etc. In the big
+picture it makes very little difference CPU wise as most of the time the
+work-per-coroutine is high.
+
+LLMs love reducing allocs via coroutine/continuation changes as the allocs
+number in microbenches is stable and via such optimizations is easy to reduce
+(at the cost of readability/clarity).
+
+
+## Write HALO aware wrappers
+
+Constructor arguments don't currently propagate a safe elide context.
+
+**Do:** Use a factory function and consider `coro_await_elidable_argument` when
+the child is guaranteed to finish before the wrapper does.
+
+```cpp
+auto handle(SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT ss::future<>&& f) {
+    ...
+    co_await f;
+    ...
+}
+```
+
+**Don't:** Add the attribute if the child can escape the wrapper. It is a
+lifetime contract, not just an optimization hint.
+
+```cpp
+auto detach(SEASTAR_CORO_AWAIT_ELIDABLE_ARGUMENT ss::future<>&& f) {
+    ...
+    background(std::move(f)); // Wrong: f escapes the wrapper.
+    ...
+}
+```
+
+Again keep in mind that this level of tuning is only relevant for very commonly
+used helper functions.
+
+## Avoid recursive coroutine chains
+
+The compiler can't embed a potentially unbounded number of frames.
+
+**Do:** Use an iterative coroutine where practical.
+
+```cpp
+ss::future<> visit(node* n) {
+  for (; n != nullptr; n = n->next) {
+    co_await visit_one(n);
+  }
+}
+```
+
+**Don't:** Expect HALO to optimize recursive coroutine calls.
+
+```cpp
+ss::future<> visit(node* n) {
+  if (n == nullptr) {
+    co_return;
+  }
+
+  co_await visit_one(n);
+  co_await visit(n->next);
+}
+```
+
+
+## Yield in CPU heavy loops
+
+**Do:** Use `coroutine::maybe_yield` to remain reactor friendly.
+
+```cpp
+for (const auto& item : items) {
+  process(item);
+  co_await ss::coroutine::maybe_yield();
+}
+```
+
+**Don't:** Run an unbounded loop without a scheduling point.
+
+```cpp
+for (const auto& item : unbounded_input) {
+  process(item);
+}
+```
+
+Note that this is often the preferred way if it allows to keep (leaf) functions coroutine free (sync code is still the fastest).
+
+## References
+
+- [Coroutines Optimization Opportunities from Compiler's perspective](https://chuanqixu9.github.io/c++/2026/03/27/C++20-Coroutines-from-compiler-and-library-authors-perspective.en.html)
+- [Clang `coro_await_elidable`](https://clang.llvm.org/docs/AttributeReference.html#coro-await-elidable)
+- [Clang `coro_await_elidable_argument`](https://clang.llvm.org/docs/AttributeReference.html#coro-await-elidable-argument)
+- [Clang `coro_only_destroy_when_complete`](https://clang.llvm.org/docs/AttributeReference.html#coro-only-destroy-when-complete)

--- a/docs/writing-scalable-and-high-performance-code.md
+++ b/docs/writing-scalable-and-high-performance-code.md
@@ -1,0 +1,136 @@
+# Writing scalable and high performance code
+
+## Scale
+
+Redpanda runs at scale and it is good to keep this in mind when writing code.
+Most tests do not run at high scale, and the scale tests that do run have
+limited coverage. So we cannot expect all scale issues to be caught by testing
+and proactive scale-sensitive choices can go a long way towards mitigating that.
+
+Some specific things to keep in mind when writing for scale, such as what data
+structure to use, are very important, and these are addressed in subsections
+below.
+
+### Memory allocation limits (128K rule)
+
+**As a guideline, do not allocate more than 128 KiB of contiguous memory in
+redpanda after startup.**
+
+Allocations larger than 128 KiB have a relatively high likelihood of failing
+allocation even when substantial free memory is available due to
+seastar-specific fragmentation. These failures won’t usually occur in our tests
+(except perhaps very long running ones), but will fail at some inopportune
+moment at an important customer.
+
+128 KiB is not a magic number that it is guaranteed to work, but it is small
+enough that we *believe* it won’t be a significant problem even in fragmented
+heaps and it aligns with the existing sizes of some very common allocations such
+as `iobuf` fragments.
+
+The most common causes of large contiguous allocations are large arrays or array
+like containers (such as `std::vector`, or the use of containers that are backed
+by those types of containers, such as `std::unordered_map` or
+`absl::flat_hash_map`).
+
+#### Problematic containers
+
+Containers below make large contiguous allocations and should be avoided if the
+container size could reasonably exceed the 128K rule.
+
+| **Container**                                       | **Approximate contiguous allocation size** | **Notes**                                                                                                                                                                                                                                                                                                                      |
+| --------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `std::vector<T>`                                    | `2 * size() * sizeof(T)`                   | Factor of two comes from the resize step: the size doubles so will contain `2 * size()` at that point. In some cases you remove this factor of two when you know the final size and use `reserve()` or `resize()`.                                                                                                             |
+| `std::unordered_map<K, V>`, `std::unordered_set<K>` | `16 * size()`                              | Factor of 16 comes from `2 * sizeof(void *)` where 2 is due to the doubling during growth (so half the buckets will be empty) and `sizeof(void *)` reflects that these are closed-addressed hash maps which have a single pointer per bucket. The size of the contiguous allocation does not depend on the size of `K` or `V`. |
+| `absl::flat_hash_map<K, V>`                         | `2.3 * (sizeof(K) + sizeof(V)) * size()`   | The contiguous allocation comes from the key/value array, as the separate control array is generally much smaller. The factor of 2.3 comes from ~1.15 size → capacity ratio (due to load factor) times 2 for doubling.                                                                                                         |
+| `absl::node_hash_map<K, V>`                         | `2.3 * (8 + 1) * size()` (? untested)      | Similar to `std::unordered_map`, except an additional 1 byte per slot (the `+ 1` part) for control byte, and a `1.15x` factor due to load factor.                                                                                                                                                                              |
+
+If all else fails (e.g., a third party lib really wants big contiguous
+allocations), make the allocations at startup, when large contiguous blocks are
+easy to obtain.
+
+### Preferred datastructures:
+
+Prefer these data structures as they are resistant to oversized allocations and
+memory fragmentation.
+
+| **Datastructure** | **Preferred**      | **Caveats**                                                                                              | **Alternatives**                                                                                                                                                                                                                                                                                                                                                   |
+| ----------------- | ------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Array, vector     | `chunked_vector`   |                                                                                                          | `std::deque`: Fine from oversized allocation perspective. The chunk size cannot be controlled. As soon as 1 element is added, the full chunk is allocated, making it a memory hog in scenarios where you have one per X (for example partition, topic etc.) as the overhead will be large.`boost::deque`: as above, but at least the chunk size can be controlled. |
+| Unordered Map     | `chunked_hash_map` | Insert and erase invalidates all iterators: Don’t do `map.erase(it++)`, instead do `it = map.erase(it)`. | `absl::node_hash_map`: Useful if pointer stability is needed (try working around first). Don't use if scaling with partitions etc as this will suffer from oversized allocs                                                                                                                                                                                        |
+| Ordered Map       | `absl::btree_map`  |                                                                                                          | `std::map`: Use if pointer stability is needed (probably can work around that by using std::unique_ptr values in the map)                                                                                                                                                                                                                                          |
+
+### Managing Concurrency in the system
+
+Seastar makes it very easy to write async and concurrent code and thus hide IO
+latency. This allows for writing high performing code.
+
+At the same time care needs to be taken to not introduce too much concurrency
+into the system. Each concurrent task comes with memory usage that depending on
+the task can be relatively large and if many of those tasks are in the system
+waiting it can lead to OOM.
+
+Think about how much concurrency is needed to adequately hide latency. For
+sending large chunks of data to a local service with low latency not much
+concurrency is needed, e.g.: uploading chunks of 128KiB to local S3 you can get
+very good throughput on a single connection so not much concurrency is needed.
+Writing 4KiB blocks to EBS will need higher concurrency to get good throughput.
+
+Keep in mind that effectively most things are shard local so often higher
+concurrency is already induced by having multiple shards.
+
+There is also various patterns to manage concurrency and memory usage.
+
+#### Limit the concurrency for a certain operation
+
+Use `ss::max_concurrent_for_each` to limit max concurrency. Concurrency larger
+than 100 is probably never a good idea, most of the time 10 is probably
+approximately right but there is no hard rule. Keep above advice in mind.
+
+Avoid using `ss::parallel_for_each` for ranges that can grow large such as
+segments, topics or partitions.
+
+Be aware of implicitly nested `ss::max_concurrent_for_each` usages. If it’s a
+concern use a `ssx::semaphore` to better limit active concurrency.
+
+#### Limit memory usage for a certain class of operations
+
+An alternative approach if tasks themselves are not an issue is to limit memory
+usage directly. We generally do this by using a `ssx::semaphore` which counts
+the total available memory for this operation. Tasks try to draw from this
+before they are allowed to execute and otherwise have to wait.
+
+This is generally the better way to limit concurrency but can be hard to limit
+if it’s hard to estimate how much memory a task will need or the memory need
+isn’t known a-priori at all. Be careful in those cases as task throughput can be
+starved if memory estimation is wrong.
+
+## Performance
+
+This section is a stub.
+
+Unlike scale, you don’t need to design most of the code you write for the
+highest performance (i.e., doing the required job as fast as possible). Most
+code is cold or very cold. Even in hot paths, simple, straightforward code
+should be the default.
+
+Only in specific cases where profiling information shows a hotspot, or you have
+solid reasoning to believe you are writing hot code, then some deviation from
+“simple, straightforward” might be appropriate.
+
+That disclaimer aside, here is a short list of (unsorted) performance notes:
+
+### Miscellaneous Performance Notes
+
+#### iobuf is not super cheap to copy or share
+
+`iobuf` can be copied in two different ways: `iobuf::copy()` which creates a
+byte-wise copy of all underlying buffers, or `iobuf::share()` which creates a
+“logical” copy that shares the underlying buffers and so avoids a byte-wise
+copy. Both of these can be relatively expensive: `copy()` in the obvious way
+that it effective needs to do a `memcpy` of the entire buffer, and `share()`
+because it needs to do an atomic operation and an allocation (though this is
+O(1) work, so less relevant for larger buffers).
+
+This means that *if* you have a sync function which takes an `iobuf` and does
+not mutate it, just take it as a `const iobuf&` instead of by-value (followed by
+moves) which is a pattern which occurs often in our codebase.


### PR DESCRIPTION
Move the writing efficient code guidelines from the cupboard into the repo and link them in CLAUDE.md.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes


* none
