### PR TITLE
[v26.2.x] CORE-17096 Revert "build/deps: upgrade c-ares to 1.34.7 (CVE-2026-33630)"

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -355,7 +355,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "G6xiSAh5Rh3tpLdV0zGaF5o5aVrbuUY+p/jbGTTkPhU=",
+        "bzlTransitiveDigest": "Vd5fleZJE/7J3DfoAyhqn6jEuL4ysbCxoJiDfu5Amcg=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools",
@@ -401,9 +401,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:c-ares.BUILD",
-              "sha256": "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
-              "strip_prefix": "c-ares-1.34.7",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz"
+              "sha256": "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
+              "strip_prefix": "c-ares-1.34.6",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz"
             }
           },
           "hdrhistogram": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -44,9 +44,9 @@ def data_dependency():
     http_archive(
         name = "c-ares",
         build_file = "//bazel/thirdparty:c-ares.BUILD",
-        sha256 = "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
-        strip_prefix = "c-ares-1.34.7",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz",
+        sha256 = "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
+        strip_prefix = "c-ares-1.34.6",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR #31634

Reverts the c-ares 1.34.7 upgrade (backported to this branch in #31484) due to CORE-17096: c-ares 1.34.7 carries an upstream regression ([c-ares/c-ares#1256](https://github.com/c-ares/c-ares/issues/1256)) where a DNS query's completion callback can silently never be invoked, which permanently wedges an internal broker-to-broker RPC transport after a peer broker restart. No v26.2.x release has shipped 1.34.7 (v26.2.1 is on 1.34.6), so this revert prevents the next tag from shipping the regression.

- Command: `git cherry-pick -x dbf137b0c73fbb2dedceb627c0a2727ad7130b8a`
- Commits backported: 1
- Conflicts resolved: 1

## Conflict details

- dbf137b0c73 (`MODULE.bazel.lock`): the `bzlTransitiveDigest` of the `non_module_dependencies` extension differs per branch, so the dev value could not apply. Resolved by regenerating the lockfile on this branch with `bazel mod deps --lockfile_mode=update`; the regenerated digest is committed here (not left for CI, which does not push corrections back).

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

### Bug Fixes

* The c-ares 1.34.7 upgrade (CVE-2026-33630 fix) previously merged to this branch was reverted before any release shipped it, due to an upstream c-ares regression (c-ares/c-ares#1256) that can permanently wedge internal broker-to-broker RPC connections after a peer broker restart. c-ares remains at 1.34.6; CVE-2026-33630 remains unfixed and the upgrade will be re-applied once an upstream c-ares release also fixes the regression.
