### PR TITLE
[v26.1.x] CORE-17096 Revert "build/deps: upgrade c-ares to 1.34.7 (CVE-2026-33630)"

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -308,7 +308,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "s8tuS4I8QI+HLkRamy+fBze/D3qUhC5bE3ilUzQANEQ=",
+        "bzlTransitiveDigest": "bigwKUfn/CT2/ANBEUuaC4yqP/Vj8DFJWbSSvpwWmWk=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -350,9 +350,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:c-ares.BUILD",
-              "sha256": "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
-              "strip_prefix": "c-ares-1.34.7",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz"
+              "sha256": "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
+              "strip_prefix": "c-ares-1.34.6",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz"
             }
           },
           "hdrhistogram": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -40,9 +40,9 @@ def data_dependency():
     http_archive(
         name = "c-ares",
         build_file = "//bazel/thirdparty:c-ares.BUILD",
-        sha256 = "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
-        strip_prefix = "c-ares-1.34.7",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz",
+        sha256 = "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
+        strip_prefix = "c-ares-1.34.6",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR #31634

Reverts the c-ares 1.34.7 upgrade (backported to this branch in #31486, shipped in v26.1.16) due to CORE-17096: c-ares 1.34.7 carries an upstream regression ([c-ares/c-ares#1256](https://github.com/c-ares/c-ares/issues/1256)) where a DNS query's completion callback can silently never be invoked, which permanently wedges an internal broker-to-broker RPC transport after a peer broker restart. v26.1.16 clusters are affected in production.

- Command: `git cherry-pick -x dbf137b0c73fbb2dedceb627c0a2727ad7130b8a`
- Commits backported: 1
- Conflicts resolved: 1

## Conflict details

- dbf137b0c73 (`MODULE.bazel.lock`): the `bzlTransitiveDigest` of the `non_module_dependencies` extension differs per branch, so the dev value could not apply. Resolved by regenerating the lockfile on this branch with `bazel mod deps --lockfile_mode=update`. The regenerated digest is byte-identical to the one this branch had before the 1.34.7 bump (no other `.bzl` content changed on this branch since), confirming the revert restores the exact pre-bump state.

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x
