### PR TITLE
[v25.3.x] CORE-17096 Revert "build/deps: upgrade c-ares to 1.34.7 (CVE-2026-33630)"

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -303,7 +303,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "ZvbAj9FXGv2EuD26/WZDFp+4wnYOeQWJ48lyWNebBhk=",
+        "bzlTransitiveDigest": "7H4VLTieQdBj4Au+UM/Rbh8F7/sdshXLpJ8qypbpmPE=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -345,9 +345,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:c-ares.BUILD",
-              "sha256": "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
-              "strip_prefix": "c-ares-1.34.7",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz"
+              "sha256": "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
+              "strip_prefix": "c-ares-1.34.6",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz"
             }
           },
           "hdrhistogram": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -40,9 +40,9 @@ def data_dependency():
     http_archive(
         name = "c-ares",
         build_file = "//bazel/thirdparty:c-ares.BUILD",
-        sha256 = "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327",
-        strip_prefix = "c-ares-1.34.7",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.7.tar.gz",
+        sha256 = "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
+        strip_prefix = "c-ares-1.34.6",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31634

- Command: git cherry-pick -x dbf137b0c7
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31634-v25.3.x-1787136499

## Conflict details

- dbf137b0c7 (MODULE.bazel.lock): the `bzlTransitiveDigest` line conflicted because
  `v25.3.x` and `dev` carry different digests for the `non_module_dependencies`
  extension (the branches' `.bzl` inputs have diverged, and the lockfile schema
  around it differs too — `v25.3.x` uses `recordedFileInputs`/`recordedDirentsInputs`/
  `envVariables` where `dev` uses `recordedInputs`). Taking the incoming `dev` digest
  would have been wrong for this branch, so it was resolved to
  `7H4VLTieQdBj4Au+UM/Rbh8F7/sdshXLpJ8qypbpmPE=` — the value `v25.3.x` itself had
  immediately before the c-ares 1.34.7 upgrade (commit 936958c1e2) that this commit
  reverts. The c-ares `sha256`/`strip_prefix`/`url` entries auto-merged cleanly back
  to 1.34.6.

## ⚠️ Generated files

The following generated file was part of the cherry-picked commit:

- MODULE.bazel.lock

Note: this file was **not** taken as-is from the source branch. Both changed files
(`MODULE.bazel.lock` and `bazel/repositories.bzl`) were verified byte-identical to
`936958c1e2^`, i.e. exactly the state `v25.3.x` had before the c-ares 1.34.7 upgrade
this commit reverts, so the lockfile content is the genuine one for this branch with
c-ares 1.34.6. Re-running `bazel mod deps --lockfile_mode=update` should therefore be
a no-op; if it does produce a diff, commit the regenerated file before merging.
