### PR TITLE
raft: re-apply leader commit index after a follower flush

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2224,6 +2224,11 @@ consensus::do_append_entries(append_entries_request&& r) {
                 reply.last_flushed_log_index = std::min(
                   adjusted_prev_log_index, _flushed_offset);
                 reply.result = reply_result::success;
+                // the request proved our log matches the leader's up to
+                // adjusted_prev_log_index, so its commit index is usable for
+                // that prefix even though we append nothing here
+                maybe_update_follower_commit_idx(
+                  request_metadata.commit_index, adjusted_prev_log_index);
                 co_return reply;
             }
         }
@@ -2261,8 +2266,10 @@ consensus::do_append_entries(append_entries_request&& r) {
         }
 
         co_await std::move(f);
+        // reached only when adjusted_prev_log_index >= lstats.dirty_offset, so
+        // our whole log is a verified prefix of the leader's
         maybe_update_follower_commit_idx(
-          model::offset(request_metadata.commit_index));
+          model::offset(request_metadata.commit_index), lstats.dirty_offset);
         reply.last_flushed_log_index = _flushed_offset;
         reply.result = reply_result::success;
         co_return reply;
@@ -2312,6 +2319,10 @@ consensus::do_append_entries(append_entries_request&& r) {
         _last_quorum_replicated_index_with_flush = std::min(
           model::prev_offset(truncate_at),
           _last_quorum_replicated_index_with_flush);
+        // the entries the leader reported as committed are about to be
+        // replaced
+        _last_leader_commit_index = std::min(
+          model::prev_offset(truncate_at), _last_leader_commit_index);
         // update flushed offset since truncation may happen to already
         // flushed entries
         _flushed_offset = std::min(
@@ -2388,7 +2399,8 @@ consensus::do_append_entries(append_entries_request&& r) {
           request_metadata.last_visible_index, _last_leader_visible_offset);
         _confirmed_term = _term;
 
-        maybe_update_follower_commit_idx(request_metadata.commit_index);
+        maybe_update_follower_commit_idx(
+          request_metadata.commit_index, ofs.last_offset);
 
         if (_follower_recovery_state) {
             _follower_recovery_state->update_progress(
@@ -2546,6 +2558,7 @@ consensus::truncate_to_latest_snapshot(storage::truncate_prefix_config cfg) {
           // when log was prefix truncate flushed offset should be equal to at
           // least last snapshot index
           _flushed_offset = std::max(_last_snapshot_index, _flushed_offset);
+          maybe_advance_follower_commit_idx();
       });
 }
 
@@ -2760,6 +2773,7 @@ ss::future<> consensus::write_snapshot(write_snapshot_cfg cfg) {
      * the offset will be at most equal to log start offset
      */
     _flushed_offset = std::max(last_included_index, _flushed_offset);
+    maybe_advance_follower_commit_idx();
 
     co_await _snapshot_lock.with([this, last_included_index]() mutable {
         return _configuration_manager.prefix_truncate(last_included_index);
@@ -2982,6 +2996,7 @@ ss::future<consensus::flushed> consensus::flush_log() {
     _flushed_offset = std::max(flushed_up_to, _flushed_offset);
     vlog(_ctxlog.trace, "flushed offset updated: {}", _flushed_offset);
 
+    maybe_advance_follower_commit_idx();
     maybe_update_majority_replicated_index();
     maybe_update_leader_commit_idx();
 
@@ -3346,22 +3361,42 @@ consensus::do_maybe_update_leader_commit_idx(ssx::semaphore_units u) {
 }
 
 void consensus::maybe_update_follower_commit_idx(
-  model::offset request_commit_idx) {
+  model::offset leader_commit_idx, model::offset matched_upto) {
     // Raft paper:
     //
     // If leaderCommit > commitIndex, set commitIndex =
     // min(leaderCommit, index of last new entry)
-    if (request_commit_idx > _commit_index) {
-        auto new_commit_idx = std::min(request_commit_idx, _flushed_offset);
-        if (new_commit_idx > _commit_index) {
-            _commit_index = new_commit_idx;
-            vlog(
-              _ctxlog.trace, "Follower commit index updated {}", _commit_index);
-            _replication_monitor.notify_committed();
-            _commit_index_updated.broadcast();
-            _event_manager.notify_commit_index();
-        }
+    //
+    // A leader may report a commit index past the end of our log (recovery
+    // requests), so only the part backed by the prefix this request verified is
+    // usable. The value is remembered because the entries it covers become
+    // committed locally only once they are flushed, which may be well after
+    // this request was replied to.
+    _last_leader_commit_index = std::max(
+      _last_leader_commit_index, std::min(leader_commit_idx, matched_upto));
+    maybe_advance_follower_commit_idx();
+}
+
+void consensus::maybe_advance_follower_commit_idx() {
+    if (is_elected_leader()) {
+        /**
+         * do_maybe_update_leader_commit_idx() must remain the only writer of a
+         * leader's commit index: its update is also the only place where a
+         * joint configuration is committed and where the leader's visible index
+         * advances.
+         */
+        return;
     }
+    const auto new_commit_idx = std::min(
+      _last_leader_commit_index, _flushed_offset);
+    if (new_commit_idx <= _commit_index) {
+        return;
+    }
+    _commit_index = new_commit_idx;
+    vlog(_ctxlog.trace, "Follower commit index updated {}", _commit_index);
+    _replication_monitor.notify_committed();
+    _commit_index_updated.broadcast();
+    _event_manager.notify_commit_index();
 }
 
 void consensus::update_follower_states(const group_configuration& cfg) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3353,7 +3353,7 @@ void consensus::maybe_update_follower_commit_idx(
     // min(leaderCommit, index of last new entry)
     if (request_commit_idx > _commit_index) {
         auto new_commit_idx = std::min(request_commit_idx, _flushed_offset);
-        if (new_commit_idx != _commit_index) {
+        if (new_commit_idx > _commit_index) {
             _commit_index = new_commit_idx;
             vlog(
               _ctxlog.trace, "Follower commit index updated {}", _commit_index);

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -695,7 +695,9 @@ private:
     ss::future<std::error_code>
     replicate_configuration(ssx::semaphore_units u, group_configuration);
 
-    void maybe_update_follower_commit_idx(model::offset);
+    void maybe_update_follower_commit_idx(
+      model::offset leader_commit_idx, model::offset matched_upto);
+    void maybe_advance_follower_commit_idx();
 
     void arm_vote_timeout();
     void update_node_append_timestamp(vnode);
@@ -984,6 +986,20 @@ private:
      */
     model::offset _last_quorum_replicated_index_with_flush;
     model::offset _last_leader_visible_offset;
+    /**
+     * Commit index last reported by a leader, clamped to the log prefix that
+     * the reporting request proved to match the leader's log.
+     *
+     * Kept separately from _commit_index because a follower may only commit
+     * what it flushed, while it replies to heartbeats without flushing: the
+     * commit index derived from a request is clamped by a flushed offset that
+     * may still be stale. Re-applied whenever _flushed_offset moves forward,
+     * since the leader stops sending full heartbeats as soon as our flush is
+     * reported back and lightweight heartbeats carry no commit index.
+     *
+     * Clamped down together with _flushed_offset on suffix truncation.
+     */
+    model::offset _last_leader_commit_index;
     flush_after_append _last_write_flushed;
     offset_monitor<model::offset> _consumable_offset_monitor;
     ss::condition_variable _follower_reply;

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -1211,3 +1211,119 @@ TEST_F_CORO(raft_fixture, test_leadership_blocked_replicas_can_elect_leader) {
     auto leader = co_await wait_for_leader(60s);
     ASSERT_NE_CORO(leader, blocked_follower);
 }
+
+namespace {
+/**
+ * Builds the request a leader sends as a full heartbeat: no batches and no
+ * request to flush, exactly as raft::service::make_append_entries_request does.
+ * The log metadata describes the recipient's own log end, so the request is
+ * accepted and takes the empty-batch path of consensus::do_append_entries.
+ */
+append_entries_request
+make_full_heartbeat(const consensus& to, vnode from, model::offset commit) {
+    return {
+      from,
+      to.self(),
+      protocol_metadata{
+        .group = to.group(),
+        .commit_index = commit,
+        .term = to.term(),
+        .prev_log_index = to.dirty_offset(),
+        .prev_log_term = to.get_term(to.dirty_offset()),
+        .last_visible_index = to.dirty_offset(),
+        .dirty_offset = to.dirty_offset(),
+      },
+      {},
+      0,
+      flush_after_append::no};
+}
+} // namespace
+
+/**
+ * A follower may only commit what it has flushed, so a leader commit index that
+ * arrives while the follower's log tail is still unflushed gets clamped away.
+ * The follower's own flush has to finish the job, because the leader stops
+ * sending full heartbeats as soon as that flush is reported back
+ * (heartbeat_manager::needs_full_heartbeat) and lightweight heartbeats carry no
+ * commit index at all.
+ *
+ * The two events must commute: whichever of "was told the leader's commit
+ * index" and "flushed its own tail" happens second has to leave the follower
+ * committed. One follower is driven in each order.
+ *
+ * EXPECT rather than ASSERT throughout, so that the process wide config changed
+ * by disable_background_flushing() is always restored; an early co_return would
+ * leak it into every later test in the binary.
+ */
+TEST_F_CORO(raft_fixture, follower_commit_index_converges_on_own_flush) {
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto leader = node(leader_id).raft();
+
+    /**
+     * With background flushing off, an explicit refresh_commit_index() is the
+     * only thing that can move any replica's flushed offset, which puts the
+     * interleaving under the test's control rather than the scheduler's. It
+     * also pins the leader's own commit index, so the heartbeats it keeps
+     * sending carry a stale commit index and cannot repair a follower behind
+     * our back.
+     */
+    co_await disable_background_flushing();
+
+    auto result = co_await leader->replicate(
+      make_batches({{"k_1", "v_1"}, {"k_2", "v_2"}}),
+      replicate_options(consistency_level::leader_ack));
+    EXPECT_TRUE(result.has_value());
+    const auto target = result.value().last_offset;
+
+    co_await tests::cooperative_spin_wait_with_timeout(10s, [this, target] {
+        return std::all_of(
+          nodes().begin(), nodes().end(), [target](const auto& p) {
+              return p.second->raft()->dirty_offset() == target;
+          });
+    });
+
+    std::vector<model::node_id> followers;
+    for (const auto& [id, _] : nodes()) {
+        if (id != leader_id) {
+            followers.push_back(id);
+        }
+    }
+    EXPECT_EQ(followers.size(), 2u);
+
+    // case 1: told the commit index first, flushed second. The order that
+    // leaves the follower stuck.
+    {
+        auto victim = node(followers[0]).raft();
+        EXPECT_LT(victim->flushed_offset(), target);
+
+        auto reply = co_await victim->append_entries(
+          make_full_heartbeat(*victim, leader->self(), target));
+        // a rejected request would make the rest of the case vacuous
+        EXPECT_EQ(reply.result, reply_result::success);
+        // clamped to the unflushed offset, and the leader's value dropped
+        EXPECT_LT(victim->committed_offset(), target);
+
+        co_await victim->refresh_commit_index();
+        EXPECT_EQ(victim->flushed_offset(), target);
+        EXPECT_EQ(victim->committed_offset(), target)
+          << "commit index did not converge after the follower's own flush";
+    }
+
+    // case 2: the same two events the other way round
+    {
+        auto victim = node(followers[1]).raft();
+        EXPECT_LT(victim->flushed_offset(), target);
+
+        co_await victim->refresh_commit_index();
+        EXPECT_EQ(victim->flushed_offset(), target);
+
+        auto reply = co_await victim->append_entries(
+          make_full_heartbeat(*victim, leader->self(), target));
+        EXPECT_EQ(reply.result, reply_result::success);
+        EXPECT_EQ(victim->committed_offset(), target)
+          << "commit index did not converge when the flush came first";
+    }
+
+    co_await reset_background_flushing();
+}


### PR DESCRIPTION
This needs a follower that can answer without writing to disk, which is not the default:
`acks=1`, `acks=0`, or `acks=all` with write caching on (`write_caching_default` is
`false`). On the default path the leader tells the follower to flush before it answers, so
the follower commits as it answers and none of the below applies.

Take `acks=1`. A producer writes one batch. The leader appends it, answers the producer,
and forwards it to both followers. Nobody writes to disk yet, so each follower parks the
batch in memory and arms a 100ms timer to flush it.

The leader flushes. Follower A's timer fires, it flushes too and reports its new flushed
offset. That is a majority on disk, so the leader advances its own commit index to offset
N. Its next heartbeat carries the figure: you may commit up to N.

Follower A commits N and is done. Follower B's timer has not fired. B holds the batch in
memory with nothing on disk, and a follower may only commit what it flushed, so B takes
`min(N, its own flushed offset)`, keeps its old commit index, and drops N on the floor.
Correct so far.

A few milliseconds later B's timer fires and the batch reaches disk. B is now durable up
to N. Nothing rechecks the commit index, so B still reports the old one.

The next heartbeat ought to fix that. It does not:

1. B's reply to the earlier heartbeat was rewritten on its way out with B's *post*-flush
   offset (`append_entries_buffer`, deliberate — it lets the leader commit a round trip
   sooner). The leader now believes B has flushed N.
2. `needs_full_heartbeat()` compares exactly that, concludes B is caught up, and switches
   to lightweight heartbeats.
3. Lightweight heartbeats carry no commit index and never reach `do_append_entries`.

Neither side raises the subject again. The producer has stopped writing, so nothing breaks
the deadlock and B sits behind indefinitely. `state_machine_manager` reads
`[_next, committed_offset()]`, so B's state machines stop applying the tail of the log.

Nothing is unsafe: a follower behind on commit is Raft-legal, and the leader is unaffected.

The fix makes B recheck when it flushes. It remembers the commit index the leader
reported, clamped to the prefix the request verified, and re-derives it wherever
`_flushed_offset` moves. The leader gate sits inside `maybe_advance_follower_commit_idx()`
so `do_maybe_update_leader_commit_idx()` stays the only writer of a leader's commit index;
that update is also the only place a joint configuration is committed.

The first commit stands alone: the old check let a follower's commit index move backwards.

The new test drives one follower in each order of the two events. Without the second
commit it fails 40 of 40 runs; with it, 40 of 40 pass. It also clears a ~9.5% flake in
`all_acks_fixture.validate_recovery`, 46/500 to 0/500. `//src/v/raft/...` is green.

That flake — `all_acks_fixture.validate_recovery` in
`//src/v/raft/tests:basic_raft_fixture_test` — is how the bug surfaced, flagged by a sweep
for an unrelated seastar task-shuffling change that a control arm then cleared of blame.

## Backports Required

- [x] none - papercut/not impactful enough to backport

Liveness only, and it clears on the next write or on a leadership change. No effect on
reads (`last_visible_index` is updated before the flush is awaited) or on tiered storage
uploads (the archiver is leader-driven).

## Release Notes

* none