### PR TITLE
net: bound DNS lookups and replace the resolver on a 60s timeout 

### DIFF
--- a/src/v/net/dns.cc
+++ b/src/v/net/dns.cc
@@ -10,26 +10,88 @@
  */
 #include "net/dns.h"
 
+#include "base/vlog.h"
+#include "ssx/future-util.h"
 #include "ssx/mutex.h"
 #include "utils/unresolved_address.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/with_timeout.hh>
 #include <seastar/net/dns.hh>
+#include <seastar/util/log.hh>
 
+#include <chrono>
 #include <ranges>
+#include <utility>
 
 namespace net {
 
 namespace {
 
+ss::logger dnslog{"dns"};
+
+using namespace std::chrono_literals;
+
+// After this long without completion a lookup is considered lost, not slow:
+// c-ares bounds every query with its own per-query timeout and retry budget
+// (including each search-domain candidate), so a healthy channel always
+// completes -- with an answer or an error -- well within this bound.
+constexpr std::chrono::milliseconds default_resolver_liveness_timeout = 60s;
+
+struct resolver_state {
+    ss::net::dns_resolver::options options{};
+    std::chrono::milliseconds liveness_timeout{
+      default_resolver_liveness_timeout};
+    ss::net::dns_resolver resolver{options};
+    ssx::mutex lock{"resolve_dns"};
+    size_t replacements{0};
+};
+
+resolver_state& state() {
+    static thread_local resolver_state st{};
+    return st;
+}
+
+// Replaces the shard's resolver with a fresh channel. The old channel is
+// closed in the background; if the close itself never completes (it may
+// depend on the same lost callback that condemned the channel), it is
+// deliberately leaked -- bounded to one channel per replacement.
+void replace_resolver(resolver_state& st) {
+    auto old = std::exchange(st.resolver, ss::net::dns_resolver(st.options));
+    ssx::background = old.close()
+                        .handle_exception([](const std::exception_ptr&) {})
+                        .finally([old = std::move(old)] {});
+}
+
 ss::future<ss::net::hostent> lookup_host(const unresolved_address& address) {
-    static thread_local ss::net::dns_resolver resolver;
-    static thread_local ssx::mutex m{"resolve_dns"};
-    // lock
-    auto units = co_await m.get_units();
-    // resolve
-    auto host = co_await resolver.get_host_by_name(
-      address.host(), address.family());
+    auto& st = state();
+    const auto timeout = st.liveness_timeout;
+    // A holder releases the lock within one liveness timeout, so waiting
+    // longer than that means starvation, not a slow lookup.
+    auto units = co_await st.lock.get_units(
+      ssx::mutex::time_point::clock::now() + timeout);
+    ss::net::hostent host;
+    try {
+        host = co_await ss::with_timeout(
+          ss::lowres_clock::now() + timeout,
+          st.resolver.get_host_by_name(address.host(), address.family()));
+    } catch (const ss::timed_out_error&) {
+        // The channel lost this lookup's completion callback (e.g.
+        // CORE-17096) and will never make progress again; replace it so the
+        // shard's DNS recovers instead of wedging every subsequent lookup
+        // behind this one.
+        ++st.replacements;
+        vlog(
+          dnslog.error,
+          "DNS lookup of {} did not complete within {}; replacing the "
+          "shard's resolver (replacement #{})",
+          address.host(),
+          timeout,
+          st.replacements);
+        replace_resolver(st);
+        throw;
+    }
     if (host.addr_entries.empty()) {
         throw std::runtime_error(
           fmt::format(
@@ -56,5 +118,17 @@ resolve_dns_all(const unresolved_address& address) {
         })
       | std::ranges::to<std::vector>();
 }
+
+void configure_dns_resolution_for_testing(
+  ss::net::dns_resolver::options options,
+  std::chrono::milliseconds liveness_timeout) {
+    auto& st = state();
+    st.options = std::move(options);
+    st.liveness_timeout = liveness_timeout;
+    st.replacements = 0;
+    replace_resolver(st);
+}
+
+size_t dns_resolver_replacements_for_testing() { return state().replacements; }
 
 } // namespace net

--- a/src/v/net/dns.h
+++ b/src/v/net/dns.h
@@ -11,6 +11,10 @@
 #pragma once
 #include "utils/unresolved_address.h"
 
+#include <seastar/net/dns.hh>
+
+#include <chrono>
+#include <cstddef>
 #include <vector>
 
 namespace net {
@@ -19,6 +23,14 @@ namespace net {
  * Resolves addresses using seastar DNS resolver. It uses mutex to workaround
  * seastar bug causing segmentation fault when udp channel is being accessed by
  * different fibers.
+ *
+ * Lookups are additionally bounded by a liveness timeout: a lookup that
+ * neither completes nor fails within the bound (a healthy c-ares channel
+ * always does, its own per-query timeouts permitting) indicates a resolver
+ * whose completion callback was lost (see CORE-17096). Such a lookup fails
+ * with `ss::timed_out_error` and the shard's resolver is replaced with a
+ * fresh one, so a single lost callback cannot permanently wedge every
+ * subsequent lookup on the shard behind the serializing mutex.
  *
  * Returns the first address from resolve_dns_all.
  */
@@ -35,5 +47,21 @@ ss::future<ss::socket_address> resolve_dns(const unresolved_address&);
  */
 ss::future<std::vector<ss::socket_address>>
 resolve_dns_all(const unresolved_address&);
+
+/**
+ * Test-only: replaces the calling shard's resolver with one built from
+ * `options` (e.g. pointing at an in-test DNS server) and overrides the
+ * liveness timeout after which a non-completing lookup causes the shard's
+ * resolver to be replaced. Also resets the replacement counter.
+ */
+void configure_dns_resolution_for_testing(
+  ss::net::dns_resolver::options options,
+  std::chrono::milliseconds liveness_timeout);
+
+/**
+ * Test-only: number of times the calling shard's resolver was replaced
+ * after a lookup failed to complete within the liveness timeout.
+ */
+size_t dns_resolver_replacements_for_testing();
 
 } // namespace net

--- a/src/v/net/tests/BUILD
+++ b/src/v/net/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_cc_btest(
     name = "connection_rate_test",
@@ -76,6 +76,17 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_test_cc_library(
+    name = "dns_test_utils",
+    hdrs = [
+        "dns_test_utils.h",
+    ],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "dns_liveness_test",
     timeout = "moderate",
@@ -83,6 +94,7 @@ redpanda_cc_gtest(
         "dns_liveness_test.cc",
     ],
     deps = [
+        ":dns_test_utils",
         "//src/v/base",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/net/tests/BUILD
+++ b/src/v/net/tests/BUILD
@@ -77,6 +77,20 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "dns_liveness_test",
+    timeout = "moderate",
+    srcs = [
+        "dns_liveness_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "dial_test",
     timeout = "short",
     srcs = [

--- a/src/v/net/tests/BUILD
+++ b/src/v/net/tests/BUILD
@@ -103,6 +103,23 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "dns_recovery_test",
+    timeout = "short",
+    srcs = [
+        "dns_recovery_test.cc",
+    ],
+    deps = [
+        ":dns_test_utils",
+        "//src/v/base",
+        "//src/v/net",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:unresolved_address",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "dial_test",
     timeout = "short",
     srcs = [

--- a/src/v/net/tests/dns_liveness_test.cc
+++ b/src/v/net/tests/dns_liveness_test.cc
@@ -1,0 +1,258 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/seastarx.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/core/with_timeout.hh>
+#include <seastar/net/api.hh>
+#include <seastar/net/dns.hh>
+#include <seastar/net/inet_address.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/util/log.hh>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstring>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+
+using namespace std::chrono_literals;
+
+// Liveness test for the DNS resolver stack (seastar + vendored c-ares): every
+// resolution attempt must complete, successfully or with an error. A lost
+// resolver callback leaves callers waiting forever; CORE-17096 observed this
+// as an internal RPC transport wedge that required a node restart.
+//
+// The trigger is production-shaped. Kubernetes pods normally get a resolv.conf
+// with search domains such as <namespace>.svc.cluster.local, svc.cluster.local,
+// cluster.local, plus options like ndots:5. For names that c-ares treats as
+// relative, an NXDOMAIN response for one search-suffixed query makes c-ares
+// issue the next query from that query's callback. This test configures the
+// search domains directly instead of depending on the host's resolv.conf, and
+// uses arbitrary suffix names because only the chained-callback shape matters.
+// This caught the QID-reuse lost-callback bug tracked in
+// https://github.com/c-ares/c-ares/issues/1256.
+//
+// Detection is probabilistic against the broken implementation. `qid_draws`
+// below is sized for roughly 1 - e^-8 detection probability when the
+// 1/65536 QID-reuse bug is present.
+
+namespace {
+
+constexpr auto resolver_query_timeout = 5s;
+constexpr auto lookup_timeout = 30s;
+constexpr auto resolver_close_timeout = 5s;
+
+// Seven search domains plus the literal name gives eight chained queries per
+// lookup. Real Kubernetes pods may have fewer or more search domains depending
+// on cluster and node DNS config; this count is test volume, not a semantic
+// dependency.
+constexpr size_t search_domain_count = 7;
+constexpr auto queries_per_lookup = search_domain_count + 1;
+constexpr auto chains = 64;
+constexpr auto lookups_per_chain = 1024;
+constexpr auto qid_draws = chains * lookups_per_chain * queries_per_lookup;
+
+// Minimal DNS wire format handling. A query datagram is:
+//   [id:2][flags:2][qdcount:2][ancount:2][nscount:2][arcount:2]
+//   [qname: length-prefixed labels, 0-terminated][qtype:2][qclass:2]
+//   [optional additional records, e.g. EDNS OPT]
+// The reply echoes the header id and question verbatim and patches the
+// header to a no-answer NXDOMAIN response.
+std::optional<ss::temporary_buffer<char>>
+make_nxdomain_reply(std::string_view request) {
+    constexpr size_t header_size = 12;
+    if (request.size() < header_size) {
+        return std::nullopt;
+    }
+    auto pos = header_size;
+    while (pos < request.size()) {
+        auto label_len = static_cast<uint8_t>(request[pos]);
+        if (label_len == 0) {
+            pos += 1;
+            break;
+        }
+        if ((label_len & 0xc0) != 0) {
+            // Compression pointers never appear in queries.
+            return std::nullopt;
+        }
+        pos += 1 + label_len;
+    }
+    pos += 4; // qtype + qclass
+    if (pos > request.size()) {
+        return std::nullopt;
+    }
+
+    auto reply = ss::temporary_buffer<char>(pos);
+    std::memcpy(reply.get_write(), request.data(), pos);
+    auto* b = reinterpret_cast<unsigned char*>(reply.get_write());
+    b[2] = 0x81; // QR=1, opcode=QUERY, RD=1
+    b[3] = 0x83; // RA=1, rcode=NXDOMAIN
+    b[4] = 0;
+    b[5] = 1;                 // qdcount=1
+    std::memset(b + 6, 0, 6); // ancount/nscount/arcount=0 (drops any OPT)
+    return reply;
+}
+
+class mock_dns_server {
+public:
+    ss::future<> start() {
+        _chan = ss::engine().net().make_bound_datagram_channel(
+          ss::socket_address(ss::ipv4_addr("127.0.0.1", 0)));
+        _loop = run();
+        co_return;
+    }
+
+    ss::future<> stop() {
+        _stopping = true;
+        _chan.shutdown_input();
+        _chan.shutdown_output();
+        co_await std::move(_loop);
+    }
+
+    uint16_t port() const { return _chan.local_address().port(); }
+    uint64_t queries_served() const { return _queries_served; }
+
+private:
+    ss::future<> run() {
+        while (!_stopping) {
+            try {
+                auto datagram = co_await _chan.receive();
+                std::string request;
+                for (auto& buf : datagram.get_buffers()) {
+                    request.append(buf.get(), buf.size());
+                }
+                auto reply = make_nxdomain_reply(request);
+                if (!reply) {
+                    continue;
+                }
+                ++_queries_served;
+                std::array<ss::temporary_buffer<char>, 1> bufs{
+                  std::move(*reply)};
+                co_await _chan.send(datagram.get_src(), std::span(bufs));
+            } catch (...) {
+                // receive()/send() throw on shutdown_input/output.
+                co_return;
+            }
+        }
+    }
+
+    ss::net::datagram_channel _chan;
+    ss::future<> _loop = ss::make_ready_future<>();
+    bool _stopping = false;
+    uint64_t _queries_served = 0;
+};
+
+struct chain_result {
+    uint64_t completed = 0;
+    uint64_t timed_out = 0;
+};
+
+// One chain performs `lookups` sequential resolutions. Every name is unique
+// and every resolution is expected to complete (here: fail with NXDOMAIN
+// after exhausting the search list). A per-lookup timeout far above the
+// c-ares per-query timeout distinguishes "completed with an error" (fine)
+// from "no completion callback arrived" (the bug).
+ss::future<chain_result>
+run_chain(ss::net::dns_resolver* resolver, int chain_id, int lookups) {
+    auto result = chain_result{};
+    for (int i = 0; i < lookups; ++i) {
+        auto name = ss::format("q-{}-{}", chain_id, i);
+        try {
+            co_await ss::with_timeout(
+              ss::lowres_clock::now() + lookup_timeout,
+              resolver->get_host_by_name(
+                name, ss::net::inet_address::family::INET));
+            ++result.completed;
+        } catch (const ss::timed_out_error&) {
+            ++result.timed_out;
+            co_return result;
+        } catch (...) {
+            ++result.completed;
+        }
+    }
+    co_return result;
+}
+
+} // namespace
+
+TEST_CORO(dns_liveness, every_resolution_completes) {
+    // The per-query trace logging is hundreds of MB at this volume.
+    ss::global_logger_registry().set_logger_level(
+      "dns_resolver", ss::log_level::error);
+
+    auto server = mock_dns_server{};
+    co_await server.start();
+
+    auto opts = ss::net::dns_resolver::options{};
+    opts.servers = std::vector<ss::net::inet_address>{
+      ss::net::inet_address("127.0.0.1")};
+    opts.udp_port = server.port();
+    opts.timeout = resolver_query_timeout;
+
+    const std::array<ss::sstring, search_domain_count> search_domains{
+      "s0.test",
+      "s1.test",
+      "s2.test",
+      "s3.test",
+      "s4.test",
+      "s5.test",
+      "s6.test"};
+    opts.domains = std::vector<ss::sstring>(
+      search_domains.begin(), search_domains.end());
+
+    auto resolver = ss::net::dns_resolver(opts);
+
+    auto futures = std::vector<ss::future<chain_result>>{};
+    futures.reserve(chains);
+    for (int c = 0; c < chains; ++c) {
+        futures.push_back(run_chain(&resolver, c, lookups_per_chain));
+    }
+    auto results = co_await ss::when_all_succeed(
+      futures.begin(), futures.end());
+
+    auto total = chain_result{};
+    for (const auto& r : results) {
+        total.completed += r.completed;
+        total.timed_out += r.timed_out;
+    }
+
+    EXPECT_EQ(total.timed_out, 0u)
+      << total.timed_out << " DNS resolution(s) timed out (" << total.completed
+      << " completed, " << server.queries_served()
+      << " DNS queries served, test configured for " << qid_draws
+      << " QID draws). One known cause is a lost c-ares callback; see "
+         "CORE-17096 and "
+         "https://github.com/c-ares/c-ares/issues/1256";
+
+    if (total.timed_out == 0) {
+        co_await resolver.close();
+    } else {
+        // Closing a resolver with an orphaned in-flight query may itself
+        // hang; bound it so the test reports the assertion above instead
+        // of timing out silently.
+        try {
+            co_await ss::with_timeout(
+              ss::lowres_clock::now() + resolver_close_timeout,
+              resolver.close());
+        } catch (const ss::timed_out_error&) {
+        }
+    }
+    co_await server.stop();
+}

--- a/src/v/net/tests/dns_liveness_test.cc
+++ b/src/v/net/tests/dns_liveness_test.cc
@@ -8,17 +8,14 @@
 // by the Apache License, Version 2.0
 
 #include "base/seastarx.h"
+#include "net/tests/dns_test_utils.h"
 #include "test_utils/test.h"
 
-#include <seastar/core/reactor.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/with_timeout.hh>
-#include <seastar/net/api.hh>
 #include <seastar/net/dns.hh>
 #include <seastar/net/inet_address.hh>
-#include <seastar/net/socket_defs.hh>
 #include <seastar/util/log.hh>
 
 #include <gtest/gtest.h>
@@ -26,11 +23,6 @@
 #include <array>
 #include <chrono>
 #include <cstddef>
-#include <cstring>
-#include <optional>
-#include <span>
-#include <string>
-#include <string_view>
 
 using namespace std::chrono_literals;
 
@@ -68,96 +60,6 @@ constexpr auto queries_per_lookup = search_domain_count + 1;
 constexpr auto chains = 64;
 constexpr auto lookups_per_chain = 1024;
 constexpr auto qid_draws = chains * lookups_per_chain * queries_per_lookup;
-
-// Minimal DNS wire format handling. A query datagram is:
-//   [id:2][flags:2][qdcount:2][ancount:2][nscount:2][arcount:2]
-//   [qname: length-prefixed labels, 0-terminated][qtype:2][qclass:2]
-//   [optional additional records, e.g. EDNS OPT]
-// The reply echoes the header id and question verbatim and patches the
-// header to a no-answer NXDOMAIN response.
-std::optional<ss::temporary_buffer<char>>
-make_nxdomain_reply(std::string_view request) {
-    constexpr size_t header_size = 12;
-    if (request.size() < header_size) {
-        return std::nullopt;
-    }
-    auto pos = header_size;
-    while (pos < request.size()) {
-        auto label_len = static_cast<uint8_t>(request[pos]);
-        if (label_len == 0) {
-            pos += 1;
-            break;
-        }
-        if ((label_len & 0xc0) != 0) {
-            // Compression pointers never appear in queries.
-            return std::nullopt;
-        }
-        pos += 1 + label_len;
-    }
-    pos += 4; // qtype + qclass
-    if (pos > request.size()) {
-        return std::nullopt;
-    }
-
-    auto reply = ss::temporary_buffer<char>(pos);
-    std::memcpy(reply.get_write(), request.data(), pos);
-    auto* b = reinterpret_cast<unsigned char*>(reply.get_write());
-    b[2] = 0x81; // QR=1, opcode=QUERY, RD=1
-    b[3] = 0x83; // RA=1, rcode=NXDOMAIN
-    b[4] = 0;
-    b[5] = 1;                 // qdcount=1
-    std::memset(b + 6, 0, 6); // ancount/nscount/arcount=0 (drops any OPT)
-    return reply;
-}
-
-class mock_dns_server {
-public:
-    ss::future<> start() {
-        _chan = ss::engine().net().make_bound_datagram_channel(
-          ss::socket_address(ss::ipv4_addr("127.0.0.1", 0)));
-        _loop = run();
-        co_return;
-    }
-
-    ss::future<> stop() {
-        _stopping = true;
-        _chan.shutdown_input();
-        _chan.shutdown_output();
-        co_await std::move(_loop);
-    }
-
-    uint16_t port() const { return _chan.local_address().port(); }
-    uint64_t queries_served() const { return _queries_served; }
-
-private:
-    ss::future<> run() {
-        while (!_stopping) {
-            try {
-                auto datagram = co_await _chan.receive();
-                std::string request;
-                for (auto& buf : datagram.get_buffers()) {
-                    request.append(buf.get(), buf.size());
-                }
-                auto reply = make_nxdomain_reply(request);
-                if (!reply) {
-                    continue;
-                }
-                ++_queries_served;
-                std::array<ss::temporary_buffer<char>, 1> bufs{
-                  std::move(*reply)};
-                co_await _chan.send(datagram.get_src(), std::span(bufs));
-            } catch (...) {
-                // receive()/send() throw on shutdown_input/output.
-                co_return;
-            }
-        }
-    }
-
-    ss::net::datagram_channel _chan;
-    ss::future<> _loop = ss::make_ready_future<>();
-    bool _stopping = false;
-    uint64_t _queries_served = 0;
-};
 
 struct chain_result {
     uint64_t completed = 0;
@@ -197,7 +99,7 @@ TEST_CORO(dns_liveness, every_resolution_completes) {
     ss::global_logger_registry().set_logger_level(
       "dns_resolver", ss::log_level::error);
 
-    auto server = mock_dns_server{};
+    auto server = net::dns_test::mock_dns_server{};
     co_await server.start();
 
     auto opts = ss::net::dns_resolver::options{};
@@ -235,8 +137,8 @@ TEST_CORO(dns_liveness, every_resolution_completes) {
 
     EXPECT_EQ(total.timed_out, 0u)
       << total.timed_out << " DNS resolution(s) timed out (" << total.completed
-      << " completed, " << server.queries_served()
-      << " DNS queries served, test configured for " << qid_draws
+      << " completed, " << server.queries_received()
+      << " DNS queries received, test configured for " << qid_draws
       << " QID draws). One known cause is a lost c-ares callback; see "
          "CORE-17096 and "
          "https://github.com/c-ares/c-ares/issues/1256";

--- a/src/v/net/tests/dns_recovery_test.cc
+++ b/src/v/net/tests/dns_recovery_test.cc
@@ -10,6 +10,7 @@
 #include "base/seastarx.h"
 #include "net/dns.h"
 #include "net/tests/dns_test_utils.h"
+#include "net/transport.h"
 #include "test_utils/test.h"
 #include "utils/unresolved_address.h"
 
@@ -17,6 +18,7 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/net/dns.hh>
 #include <seastar/net/inet_address.hh>
+#include <seastar/util/log.hh>
 
 #include <gtest/gtest.h>
 
@@ -98,5 +100,39 @@ TEST_CORO(dns_recovery, lost_lookup_fails_and_resolver_is_replaced) {
       ss::socket_address(ss::net::inet_address("127.0.0.1"), 19094));
     EXPECT_EQ(net::dns_resolver_replacements_for_testing(), 1u);
 
+    co_await server.stop();
+}
+
+// The connect deadline must bound the DNS phase of dialing: a transport
+// whose target's resolution makes no progress fails by the deadline
+// instead of pinning the caller until the (longer) resolver liveness
+// bound, let alone forever.
+TEST_CORO(dns_recovery, connect_deadline_bounds_dns) {
+    constexpr auto dial_deadline = 500ms;
+    constexpr auto dns_liveness_timeout = 5s;
+
+    auto server = net::dns_test::mock_dns_server{
+      net::dns_test::server_mode::blackhole};
+    co_await server.start();
+    net::configure_dns_resolution_for_testing(
+      make_options(server.port()), dns_liveness_timeout);
+
+    static ss::logger test_log{"dns_recovery_test"};
+    auto transport = net::base_transport(
+      net::base_transport::configuration{
+        .server_addr = net::unresolved_address("wedged.test", 19095)},
+      &test_log);
+
+    const auto start = ss::lowres_clock::now();
+    EXPECT_THROW(
+      co_await transport.connect(start + dial_deadline), ss::timed_out_error);
+    // Failed by the dial deadline, well before the resolver liveness bound.
+    EXPECT_LT(ss::lowres_clock::now() - start, dns_liveness_timeout);
+    co_await transport.stop();
+
+    // Let the abandoned lookup hit the liveness bound and replace the
+    // resolver so the test tears down with no lookup in flight.
+    co_await ss::sleep(dns_liveness_timeout + 1s);
+    EXPECT_EQ(net::dns_resolver_replacements_for_testing(), 1u);
     co_await server.stop();
 }

--- a/src/v/net/tests/dns_recovery_test.cc
+++ b/src/v/net/tests/dns_recovery_test.cc
@@ -1,0 +1,102 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/seastarx.h"
+#include "net/dns.h"
+#include "net/tests/dns_test_utils.h"
+#include "test_utils/test.h"
+#include "utils/unresolved_address.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/net/dns.hh>
+#include <seastar/net/inet_address.hh>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+// Covers the resolve_dns liveness bound: a lookup whose resolver never
+// invokes the completion callback (simulated by a DNS server that receives
+// queries and never replies, combined with a c-ares per-query timeout far
+// above the liveness timeout) must fail with a timeout instead of hanging,
+// and must not poison the shard: the per-shard resolver is replaced, so
+// both concurrent waiters and subsequent lookups complete normally.
+//
+// Without the bound, the first lookup would hold the per-shard mutex
+// forever and every later resolve_dns call on the shard -- from any
+// subsystem -- would wedge behind it (CORE-17096).
+
+namespace {
+
+constexpr auto liveness_timeout = 1s;
+// How long after the wedged lookup the concurrent one is issued: long
+// enough that the wedged query has reached the (blackholing) server, short
+// enough that the waiter's own timeout leaves margin after the holder's.
+constexpr auto waiter_stagger = 500ms;
+// Keep c-ares' own per-query timeout far above the liveness timeout so the
+// blackholed lookup is still pending -- not failed by c-ares itself -- when
+// the liveness bound fires.
+constexpr auto resolver_query_timeout = 30s;
+
+ss::net::dns_resolver::options make_options(uint16_t port) {
+    auto opts = ss::net::dns_resolver::options{};
+    opts.servers = std::vector<ss::net::inet_address>{
+      ss::net::inet_address("127.0.0.1")};
+    opts.udp_port = port;
+    opts.timeout = resolver_query_timeout;
+    return opts;
+}
+
+} // namespace
+
+TEST_CORO(dns_recovery, lost_lookup_fails_and_resolver_is_replaced) {
+    auto server = net::dns_test::mock_dns_server{
+      net::dns_test::server_mode::blackhole};
+    co_await server.start();
+    net::configure_dns_resolution_for_testing(
+      make_options(server.port()), liveness_timeout);
+
+    // A lookup the server never answers: must fail within the liveness
+    // bound rather than hang, and must trigger a resolver replacement.
+    auto wedged = net::unresolved_address("wedged.test", 19092);
+    // A second lookup issued while the first still holds the resolver
+    // mutex: must not be poisoned by the first one's fate.
+    auto waiting = net::unresolved_address("waiting.test", 19093);
+
+    auto wedged_fut = net::resolve_dns(wedged);
+    co_await ss::sleep(waiter_stagger);
+    auto waiting_fut = net::resolve_dns(waiting);
+    // Answer further queries so that after the replacement the waiter (and
+    // anything else on this shard) resolves normally.
+    server.set_mode(net::dns_test::server_mode::answer_a);
+
+    EXPECT_THROW(co_await std::move(wedged_fut), ss::timed_out_error);
+    EXPECT_EQ(net::dns_resolver_replacements_for_testing(), 1u);
+    EXPECT_GT(server.queries_received(), 0u);
+
+    auto waiting_addr = co_await std::move(waiting_fut);
+    EXPECT_EQ(
+      waiting_addr,
+      ss::socket_address(ss::net::inet_address("127.0.0.1"), 19093));
+
+    // The shard is fully recovered: fresh lookups resolve promptly against
+    // the replaced channel and no further replacement happens.
+    auto recovered_addr = co_await net::resolve_dns(
+      net::unresolved_address("recovered.test", 19094));
+    EXPECT_EQ(
+      recovered_addr,
+      ss::socket_address(ss::net::inet_address("127.0.0.1"), 19094));
+    EXPECT_EQ(net::dns_resolver_replacements_for_testing(), 1u);
+
+    co_await server.stop();
+}

--- a/src/v/net/tests/dns_test_utils.h
+++ b/src/v/net/tests/dns_test_utils.h
@@ -1,0 +1,166 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/net/api.hh>
+#include <seastar/net/socket_defs.hh>
+
+#include <array>
+#include <cstddef>
+#include <cstring>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+
+namespace net::dns_test {
+
+enum class server_mode {
+    // Answer NXDOMAIN to every query.
+    nxdomain,
+    // Answer A queries with a single 127.0.0.1 record; answer anything else
+    // with an empty NOERROR response (NODATA).
+    answer_a,
+    // Receive queries and never reply.
+    blackhole,
+};
+
+// Minimal DNS wire format handling. A query datagram is:
+//   [id:2][flags:2][qdcount:2][ancount:2][nscount:2][arcount:2]
+//   [qname: length-prefixed labels, 0-terminated][qtype:2][qclass:2]
+//   [optional additional records, e.g. EDNS OPT]
+// The reply echoes the header id and question verbatim and patches the
+// header (dropping any OPT record from the additional section).
+inline std::optional<ss::temporary_buffer<char>>
+make_reply(std::string_view request, server_mode mode) {
+    constexpr size_t header_size = 12;
+    if (request.size() < header_size) {
+        return std::nullopt;
+    }
+    auto pos = header_size;
+    while (pos < request.size()) {
+        auto label_len = static_cast<uint8_t>(request[pos]);
+        if (label_len == 0) {
+            pos += 1;
+            break;
+        }
+        if ((label_len & 0xc0) != 0) {
+            // Compression pointers never appear in queries.
+            return std::nullopt;
+        }
+        pos += 1 + label_len;
+    }
+    pos += 4; // qtype + qclass
+    if (pos > request.size()) {
+        return std::nullopt;
+    }
+    const bool is_a_query = static_cast<uint8_t>(request[pos - 4]) == 0
+                            && static_cast<uint8_t>(request[pos - 3]) == 1;
+
+    const bool answer = mode == server_mode::answer_a && is_a_query;
+    // name (pointer to the question) + type + class + ttl + rdlength + rdata
+    constexpr size_t a_record_size = 2 + 2 + 2 + 4 + 2 + 4;
+    auto reply = ss::temporary_buffer<char>(pos + (answer ? a_record_size : 0));
+    std::memcpy(reply.get_write(), request.data(), pos);
+    auto* b = reinterpret_cast<unsigned char*>(reply.get_write());
+    b[2] = 0x81; // QR=1, opcode=QUERY, RD=1
+    // RA=1, rcode: NXDOMAIN in nxdomain mode, NOERROR otherwise
+    b[3] = mode == server_mode::nxdomain ? 0x83 : 0x80;
+    b[4] = 0;
+    b[5] = 1;                 // qdcount=1
+    std::memset(b + 6, 0, 6); // ancount/nscount/arcount=0 (drops any OPT)
+    if (answer) {
+        b[7] = 1; // ancount=1
+        const std::array<unsigned char, a_record_size> a_record{
+          0xc0,
+          0x0c, // name: pointer to the question qname
+          0x00,
+          0x01, // type A
+          0x00,
+          0x01, // class IN
+          0x00,
+          0x00,
+          0x00,
+          0x3c, // ttl 60s
+          0x00,
+          0x04, // rdlength
+          127,
+          0,
+          0,
+          1}; // rdata
+        std::memcpy(b + pos, a_record.data(), a_record.size());
+    }
+    return reply;
+}
+
+class mock_dns_server {
+public:
+    explicit mock_dns_server(server_mode mode = server_mode::nxdomain)
+      : _mode(mode) {}
+
+    ss::future<> start() {
+        _chan = ss::engine().net().make_bound_datagram_channel(
+          ss::socket_address(ss::ipv4_addr("127.0.0.1", 0)));
+        _loop = run();
+        co_return;
+    }
+
+    ss::future<> stop() {
+        _stopping = true;
+        _chan.shutdown_input();
+        _chan.shutdown_output();
+        co_await std::move(_loop);
+    }
+
+    void set_mode(server_mode mode) { _mode = mode; }
+
+    uint16_t port() const { return _chan.local_address().port(); }
+    uint64_t queries_received() const { return _queries_received; }
+
+private:
+    ss::future<> run() {
+        while (!_stopping) {
+            try {
+                auto datagram = co_await _chan.receive();
+                std::string request;
+                for (auto& buf : datagram.get_buffers()) {
+                    request.append(buf.get(), buf.size());
+                }
+                ++_queries_received;
+                if (_mode == server_mode::blackhole) {
+                    continue;
+                }
+                auto reply = make_reply(request, _mode);
+                if (!reply) {
+                    continue;
+                }
+                std::array<ss::temporary_buffer<char>, 1> bufs{
+                  std::move(*reply)};
+                co_await _chan.send(datagram.get_src(), std::span(bufs));
+            } catch (...) {
+                // receive()/send() throw on shutdown_input/output.
+                co_return;
+            }
+        }
+    }
+
+    ss::net::datagram_channel _chan;
+    ss::future<> _loop = ss::make_ready_future<>();
+    server_mode _mode;
+    bool _stopping = false;
+    uint64_t _queries_received = 0;
+};
+
+} // namespace net::dns_test

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -8,6 +8,7 @@
 #include "net/dns.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/with_timeout.hh>
 
 #include <algorithm>
 #include <string_view>
@@ -166,7 +167,11 @@ base_transport::base_transport(configuration c, seastar::logger* log)
 
 ss::future<ss::connected_socket> base_transport::dial(
   const unresolved_address& target, clock_type::time_point deadline) {
-    auto resolved_address = co_await net::resolve_dns(target);
+    // Bound the DNS phase by the same deadline as the TCP dial, so a
+    // resolver that stops making progress cannot pin the caller (and,
+    // through it, the reconnect semaphore) past the connect deadline.
+    auto resolved_address = co_await ss::with_timeout(
+      deadline, net::resolve_dns(target));
     vlog(_log->trace, "Resolved address {}", resolved_address);
     co_return co_await detail::dial_single(resolved_address, deadline, _log);
 }

--- a/src/v/ssx/mutex.h
+++ b/src/v/ssx/mutex.h
@@ -66,6 +66,12 @@ public:
         return ss::get_units(_sem, 1, as);
     }
 
+    /// Waits for the mutex until `timeout`, failing the returned future
+    /// with `ss::named_semaphore_timed_out` if it is not acquired by then.
+    ss::future<units> get_units(time_point timeout) noexcept {
+        return ss::get_units(_sem, 1, timeout);
+    }
+
     std::optional<units> try_get_units() noexcept {
         return ss::try_get_units(_sem, 1);
     }


### PR DESCRIPTION
The per-shard resolve_dns mutex is held across the resolver call, so a
lookup whose c-ares completion callback is lost (CORE-17096) held it
forever and every subsequent lookup on the shard -- from any subsystem
-- queued behind it until node restart. A caller-side timeout cannot
help: it abandons the future while the inner coroutine keeps holding
the mutex.

Bound the lookup while holding the mutex instead. A healthy channel
always completes within its own per-query timeout budget, so exceeding
the generous liveness bound means the channel will never make progress
again: fail the lookup and replace the shard's resolver with a fresh
channel, closing the old one in the background (deliberately leaked if the close itself hangs).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

### Improvements

* Hardened outbound connection establishment against DNS lookups that never complete or time out.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
