### PR TITLE
heartbeat_manager: harden connection timeout handling

### DIFF
--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -354,6 +354,7 @@ void heartbeat_manager::process_reply(
              */
             if (
               r.error() == rpc::errc::client_request_timeout
+              || r.error() == rpc::errc::connection_timeout
               || r.error() == errc::timeout) {
                 consensus->update_heartbeat_status(
                   req_meta.follower_vnode, false);

--- a/src/v/rpc/reconnect_transport.cc
+++ b/src/v/rpc/reconnect_transport.cc
@@ -98,12 +98,17 @@ reconnect_transport::reconnect(clock_type::time_point connection_timeout) {
                              }
                          });
                    })
-            .handle_exception_type([connection_timeout_duration](
+            .handle_exception_type([this, connection_timeout_duration](
                                      const ss::named_semaphore_timed_out&) {
-                vlog(
-                  rpclog.trace,
-                  "timeout waiting for RPC reconnect semaphore. timeout "
-                  "duration: {}",
+                static thread_local ss::logger::rate_limit rate(
+                  std::chrono::seconds(30));
+                rpclog.log(
+                  ss::log_level::warn,
+                  rate,
+                  "timeout waiting for RPC reconnect semaphore of {} (waited "
+                  "{}): a connect attempt is holding it past this request's "
+                  "timeout",
+                  _transport->server_address(),
                   connection_timeout_duration);
                 return ss::make_ready_future<ret_t>(errc::connection_timeout);
             });


### PR DESCRIPTION
- [raft: count connection_timeout toward follower force-reconnect](https://github.com/redpanda-data/redpanda/commit/9d105b0b131b860ecc7feeb3703415de1294d57d)
- [rpc: log reconnect semaphore starvation above trace](https://github.com/redpanda-data/redpanda/commit/9cdc3fdfda7438ed3804668c58bc072bcc109dbe)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes
### Improvements

* Harden the reconnection logic when inter-broker heartbeat requests experience a connection timeout.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
