### PR TITLE
lsm/db: test that the table_cache index stays bounded under churn

### DIFF
--- a/src/v/lsm/db/tests/table_cache_test.cc
+++ b/src/v/lsm/db/tests/table_cache_test.cc
@@ -87,6 +87,30 @@ TEST_F(TableCacheTest, MaxEntries) {
     cache.close().get();
 }
 
+TEST_F(TableCacheTest, IndexBoundedUnderChurn) {
+    auto cache = make_table_cache();
+
+    // Opened only once, so it ends up on the ghost queue.
+    auto [victim, victim_size] = make_sst();
+    cache.create_iterator(victim, victim_size).get();
+
+    // Churn distinct files through the main queue.
+    for (size_t i = 0; i < default_max_entries * 20; ++i) {
+        auto [h, size] = make_sst();
+        // Open enough times to be promoted instead of ghosted.
+        for (int touch = 0; touch < 3; ++touch) {
+            cache.create_iterator(h, size).get();
+        }
+    }
+
+    tests::drain_task_queue().get();
+    // Grows with the number of files opened if main-queue evictees are not
+    // reclaimed.
+    EXPECT_LE(cache.statistics().open_file_handles, default_max_entries)
+      << cache.statistics();
+    cache.close().get();
+}
+
 TEST_F(TableCacheTest, MaxEntriesWithOpenIterators) {
     auto cache = make_table_cache();
     std::map<lsm::internal::file_handle, size_t> files;


### PR DESCRIPTION
Follow-up to #31609

Exercises the main-queue eviction path, which the existing tests never reach since nothing in them is opened more than once. One file is left untouched so it lands on the ghost queue, then distinct files are churned through the main queue; without reclamation of main-queue evictees the handle count grows with the number of files opened.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
