### PR TITLE
[v25.3.x] [CORE-17063] - security/audit: report misconfigured auth from client init

### DIFF
--- a/src/v/security/audit/client.cc
+++ b/src/v/security/audit/client.cc
@@ -23,8 +23,12 @@
 #include "security/audit/logger.h"
 #include "utils/retry.h"
 
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
+
 #include <algorithm>
 #include <chrono>
+#include <optional>
 
 namespace security::audit {
 
@@ -233,6 +237,27 @@ public:
     }
     ss::future<> client_shutdown() final { co_await _client.stop(); }
     ss::future<> do_configure() final {
+        // Set _misconfigured on a failure from any configuration step. Only
+        // create_internal_topic() reports through the kafka client's
+        // mitigate_error(), and it runs only while the local topic table has
+        // no audit topic.
+        auto fut = co_await ss::coroutine::as_future(configure_client());
+        if (fut.failed()) {
+            auto eptr = fut.get_exception();
+            if (const auto errc = misconfigured_auth_error(eptr)) {
+                co_await update_status(*errc);
+            }
+            co_await ss::coroutine::return_exception_ptr(std::move(eptr));
+        }
+        // Every step succeeded, so the authorization works. Clear a flag
+        // that an earlier attempt set.
+        co_await update_status(kafka::error_code::none);
+    }
+
+private:
+    kafka_sink_impl* sink();
+
+    ss::future<> configure_client() {
         co_await set_client_credentials();
         co_await set_auditing_permissions();
         co_await create_internal_topic();
@@ -246,11 +271,28 @@ public:
         _client.set_max_retries(size_t{5});
     }
 
-private:
-    kafka_sink_impl* sink();
-
     auth_misconfigured_t _misconfigured{auth_misconfigured_t::no};
     kafka::client::client _client;
+
+    /// The error code in `eptr`, when it says authorization is misconfigured.
+    static std::optional<kafka::error_code>
+    misconfigured_auth_error(const std::exception_ptr& eptr) {
+        try {
+            std::rethrow_exception(eptr);
+        } catch (const kafka::exception_base& ex) {
+            if (indicates_misconfigured_auth(ex.error)) {
+                return ex.error;
+            }
+        } catch (...) {
+        }
+        return std::nullopt;
+    }
+
+    /// illegal_sasl_state means a listener rejects the audit client's SASL
+    /// handshake, which needs an operator to fix the cluster.
+    static bool indicates_misconfigured_auth(kafka::error_code errc) {
+        return errc == kafka::error_code::illegal_sasl_state;
+    }
 
     ss::future<> update_status(kafka::error_code errc);
     ss::future<> do_update_status(auth_misconfigured_t);
@@ -775,14 +817,12 @@ kafka_client_impl::do_update_status(auth_misconfigured_t misconfigured) {
 
 ss::future<> kafka_client_impl::update_status(kafka::error_code errc) {
     /// If the status changed to erroneous from anything else
-    if (errc == kafka::error_code::illegal_sasl_state && !_misconfigured) {
+    if (indicates_misconfigured_auth(errc) && !_misconfigured) {
         return do_update_status(auth_misconfigured_t::yes);
     }
 
-    constexpr auto failed_codes = std::to_array(
-      {kafka::error_code::illegal_sasl_state,
-       kafka::error_code::broker_not_available});
-    const bool success = !std::ranges::contains(failed_codes, errc);
+    const bool success = !indicates_misconfigured_auth(errc)
+                         && errc != kafka::error_code::broker_not_available;
     if (success && _misconfigured) {
         /// The status changed from erroneous to anything else
         return do_update_status(auth_misconfigured_t::no);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/31629

- Command: git cherry-pick -x ffa89e374a
- Commits backported: 1
- Conflicts resolved: 1
- Commits skipped (already on target): 0
- Backport branch: ai-backport-pr-31629-v25.3.x-1787162846

## Conflict details

- ffa89e374a (src/v/security/audit/client.cc): `update_status()` conflicted because dev treats both `illegal_sasl_state` and `topic_authorization_failed` as misconfigured auth, while v25.3.x treats only `illegal_sasl_state`. The extra code came from `110deaf938` ("security/audit: make the kafka-client sink leader-independent"), which is not on v25.3.x and is not part of this PR, so the commit's `indicates_misconfigured_auth()` helper was adapted to return `illegal_sasl_state` only (doc comment trimmed to match). With that definition the rewritten `update_status()` is exactly equivalent to the v25.3.x original, and the commit's actual change — setting/clearing `_misconfigured` from `do_configure()` via `configure_client()` and `misconfigured_auth_error()` — is preserved unmodified.
