### PR TITLE
`cluster`: reconcile without a fiber per ntp

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -37,8 +37,8 @@
 #include "model/namespace.h"
 #include "raft/fundamental.h"
 #include "raft/group_configuration.h"
-#include "ssx/event.h"
 #include "ssx/future-util.h"
+#include "ssx/semaphore.h"
 #include "storage/offset_translator.h"
 #include "types.h"
 
@@ -46,11 +46,13 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
-#include <seastar/coroutine/switch_to.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/util/later.hh>
 
 #include <algorithm>
 #include <exception>
 #include <optional>
+#include <utility>
 
 /// on every core, sharded
 namespace cluster {
@@ -203,7 +205,6 @@ struct controller_backend::ntp_reconciliation_state {
     std::optional<model::revision_id> properties_changed_at;
     std::optional<model::revision_id> removed_at;
 
-    ssx::event wakeup_event{"c/cb/rfwe"};
     ss::lowres_clock::time_point last_retried_at = ss::lowres_clock::now();
     std::optional<in_progress_operation> cur_operation;
 
@@ -313,10 +314,7 @@ ss::future<> controller_backend::stop() {
     _topics.local().unregister_ntp_delta_notification(
       _topic_table_notify_handle);
 
-    for (auto& [_, rs] : _states) {
-        rs->wakeup_event.set();
-    }
-    _reconciliation_sem.broken();
+    _reconcile_sem.broken();
     co_await _gate.close();
 }
 
@@ -414,16 +412,22 @@ ss::future<> controller_backend::start() {
                   });
             }
 
-            // unblock reconciliation fibers
-            _reconciliation_sem.set_capacity(
-              _controller_backend_reconciliation_concurrency());
-
-            // register for any future updates
-            _controller_backend_reconciliation_concurrency.watch([this]() {
-                _reconciliation_sem.set_capacity(
-                  _controller_backend_reconciliation_concurrency());
-            });
-
+            ssx::repeat_until_gate_closed_or_aborted(
+              _gate,
+              _as.local(),
+              [this] {
+                  return ss::with_scheduling_group(
+                    ss::default_scheduling_group(),
+                    [this] { return reconciliation_pass(); });
+              },
+              [](const std::exception_ptr& ex) {
+                  if (!ssx::is_shutdown_exception(ex)) {
+                      vlog(
+                        clusterlog.error,
+                        "unexpected exception in reconciliation loop: {}",
+                        ex);
+                  }
+              });
             ssx::background = stuck_ntp_watchdog_fiber();
         });
     });
@@ -732,13 +736,8 @@ void controller_backend::process_delta(const topic_table::ntp_delta& d) {
     // update partition_leaders_table if needed
 
     if (d.type == topic_table_ntp_delta_type::removed) {
-        ssx::spawn_with_gate(
-          _gate, [this, ntp = d.ntp, rev = d.revision] mutable {
-              return ss::do_with(std::move(ntp), [this, rev](const auto& ntp) {
-                  return _partition_leaders_table.local().remove_leader(
-                    ntp, rev);
-              });
-          });
+        _leader_removals.emplace_back(d.ntp, d.revision);
+        _reconcile_sem.signal();
     }
 
     // notify reconciliation fiber
@@ -764,10 +763,7 @@ void controller_backend::process_delta(const topic_table::ntp_delta& d) {
         rs.properties_changed_at = d.revision;
     }
 
-    rs.wakeup_event.set();
-    if (inserted) {
-        ssx::background = reconcile_ntp_fiber(d.ntp, rs_it->second);
-    }
+    notify_pending(d.ntp);
 }
 
 void controller_backend::notify_reconciliation(const model::ntp& ntp) {
@@ -783,10 +779,7 @@ void controller_backend::notify_reconciliation(const model::ntp& ntp) {
       "[{}] notify reconciliation fiber, current state: {}",
       ntp,
       rs);
-    rs.wakeup_event.set();
-    if (inserted) {
-        ssx::background = reconcile_ntp_fiber(ntp, rs_it->second);
-    }
+    notify_pending(ntp);
 }
 
 ss::future<result<ss::stop_iteration>>
@@ -954,40 +947,104 @@ ss::future<> controller_backend::clear_orphan_topic_files(
       });
 }
 
-ss::future<> controller_backend::reconcile_ntp_fiber(
-  model::ntp ntp, ss::lw_shared_ptr<ntp_reconciliation_state> rs) {
-    if (_gate.is_closed()) {
+void controller_backend::notify_pending(const model::ntp& ntp) {
+    _pending.insert(ntp);
+    _reconcile_sem.signal();
+}
+
+ss::future<> controller_backend::reconciliation_pass() {
+    try {
+        co_await _reconcile_sem.wait(
+          _housekeeping_jitter.next_duration(),
+          std::max(_reconcile_sem.current(), size_t(1)));
+    } catch (const ss::semaphore_timed_out&) {
+        // Fallthrough
+    }
+
+    co_await drain_leader_removals();
+
+    if (_pending.empty()) {
         co_return;
     }
-    auto gate_holder = _gate.hold();
 
-    // If we don't switch here, reconciliation will inherit the scheduling group
-    // of whoever triggered it (could be e.g. the admin SG).
-    co_await ss::coroutine::switch_to(ss::default_scheduling_group());
+    auto to_reconcile = std::exchange(_pending, {});
+    auto pass = co_await ss::coroutine::as_future(
+      ss::max_concurrent_for_each(
+        to_reconcile,
+        _controller_backend_reconciliation_concurrency(),
+        [this](const model::ntp& ntp) { return reconcile_ntp(ntp); }));
 
-    while (true) {
-        co_await rs->wakeup_event.wait(_housekeeping_jitter.next_duration());
-        if (_as.local().abort_requested()) {
-            break;
+    if (pass.failed()) {
+        auto ex = pass.get_exception();
+        if (!ssx::is_shutdown_exception(ex)) {
+            vlog(clusterlog.error, "reconciliation pass failed: {}", ex);
         }
-
-        try {
-            auto sem_units = co_await _reconciliation_sem.get_units(1);
-            rs->last_retried_at = ss::lowres_clock::now();
-            co_await try_reconcile_ntp(ntp, *rs);
-            if (rs->is_reconciled()) {
-                _states.erase(ntp);
-                break;
+        // Retry ntps that were not processed.
+        for (auto& ntp : to_reconcile) {
+            auto it = _states.find(ntp);
+            if (it == _states.end()) {
+                continue;
             }
+            if (it->second->is_reconciled()) {
+                _states.erase(ntp);
+                continue;
+            }
+            _pending.insert(ntp);
+        }
+    }
+}
+
+ss::future<> controller_backend::reconcile_ntp(const model::ntp& ntp) {
+    if (_as.local().abort_requested() || _gate.is_closed()) {
+        co_return;
+    }
+
+    auto it = _states.find(ntp);
+    if (it == _states.end()) {
+        co_return;
+    }
+
+    state_ptr rs = it->second;
+
+    try {
+        rs->last_retried_at = ss::lowres_clock::now();
+        co_await try_reconcile_ntp(ntp, *rs);
+    } catch (...) {
+        auto ex = std::current_exception();
+        if (!ssx::is_shutdown_exception(ex)) {
+            vlog(
+              clusterlog.error,
+              "[{}] unexpected exception during reconciliation: {}",
+              ntp,
+              ex);
+        }
+    }
+
+    if (rs->is_reconciled()) {
+        _states.erase(ntp);
+    } else {
+        // Retry on the next reconciliation pass.
+        _pending.insert(ntp);
+    }
+}
+
+ss::future<> controller_backend::drain_leader_removals() {
+    if (_leader_removals.empty()) {
+        co_return;
+    }
+    auto removals = std::exchange(_leader_removals, {});
+    for (const auto& [ntp, revision] : removals) {
+        try {
+            co_await _partition_leaders_table.local().remove_leader(
+              ntp, revision);
         } catch (...) {
             auto ex = std::current_exception();
             if (!ssx::is_shutdown_exception(ex)) {
                 vlog(
-                  clusterlog.error,
-                  "[{}] unexpected exception during reconciliation: {}",
-                  ntp,
-                  ex);
+                  clusterlog.warn, "[{}] failed to remove leader: {}", ntp, ex);
+                continue;
             }
+            co_return;
         }
     }
 }
@@ -1944,9 +2001,8 @@ ss::future<std::error_code> controller_backend::transfer_partition(
 
     auto shard_callback = [this](const model::ntp& ntp) {
         auto& dest = container().local();
-        auto it = dest._states.find(ntp);
-        if (it != dest._states.end()) {
-            it->second->wakeup_event.set();
+        if (dest._states.contains(ntp)) {
+            dest.notify_pending(ntp);
         }
     };
 

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -22,12 +22,14 @@
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
 #include "config/property.h"
+#include "container/chunked_hash_map.h"
+#include "container/chunked_vector.h"
 #include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/group_configuration.h"
+#include "ssx/semaphore.h"
 #include "storage/api.h"
-#include "utils/adjustable_semaphore.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/chunked_fifo.hh>
@@ -271,8 +273,19 @@ private:
 
     void process_delta(const topic_table::ntp_delta&);
 
-    ss::future<> reconcile_ntp_fiber(
-      model::ntp, ss::lw_shared_ptr<ntp_reconciliation_state>);
+    /// Queues an ntp for a reconciliation attempt and wakes the reconciliation
+    /// fiber.
+    void notify_pending(const model::ntp&);
+
+    /// One iteration of the loop driving reconciliation for every ntp on this
+    /// shard: wait for work or the housekeeping tick, then reconcile the queued
+    /// ntps with bounded concurrency. Passes do not overlap, and an ntp appears
+    /// in a pass at most once, so an ntp is never reconciled concurrently with
+    /// itself.
+    ss::future<> reconciliation_pass();
+    ss::future<> reconcile_ntp(const model::ntp&);
+    ss::future<> drain_leader_removals();
+
     ss::future<>
     try_reconcile_ntp(const model::ntp&, ntp_reconciliation_state&);
     ss::future<result<ss::stop_iteration>>
@@ -429,18 +442,20 @@ private:
     ss::scheduling_group _scheduling_group;
     ss::sharded<ss::abort_source>& _as;
 
-    absl::btree_map<model::ntp, ss::lw_shared_ptr<ntp_reconciliation_state>>
-      _states;
+    using state_ptr = ss::lw_shared_ptr<ntp_reconciliation_state>;
+    absl::btree_map<model::ntp, state_ptr> _states;
     // Will hold xshard_transfer_state for partitions that are being transferred
     // to this shard.
     chunked_hash_map<model::ntp, xshard_transfer_state> _xst_states;
 
+    // ntps awaiting a reconciliation attempt in the next pass.
+    chunked_hash_set<model::ntp> _pending;
+    // Leader removals pending for deleted ntps.
+    chunked_vector<std::pair<model::ntp, model::revision_id>> _leader_removals;
+    ssx::semaphore _reconcile_sem{0, "c/cb/reconcile"};
+
     cluster::notification_id_type _topic_table_notify_handle
       = notification_id_type_invalid;
-    // Limits the number of concurrently executing reconciliation fibers.
-    // Initially reconciliation is blocked and we deposit a non-zero amount of
-    // units when we are ready to start reconciling.
-    adjustable_semaphore _reconciliation_sem{0, "c/controller-be"};
     ss::gate _gate;
 
     metrics::internal_metric_groups _metrics;


### PR DESCRIPTION
Reconciliation in the `controller_backend` was being performed by launching a background fiber per ntp being reconciled. This means that we are growing seastar's task queue directly proportionally to the number of partitions. We seem to have attempted bounding concurrency by using a `_reconciliation_sem`. However, since once we spawn this per-ntp background fiber, we have already created a new entry in seastar's task queue, even if the fiber itself eventually just sits idly waiting on the semaphore.

This is bad, both from the oversized allocation perspective (opening up potential for easy OOMs with a high partition count), and also because once we grow the queue past `seastar`'s internal `max_task_backlog`, the reactor stops honoring pre-emption until the queue is drained, leading to degraded behavior/multi-tasking. Once again, something very achievable with high partition counts.

Replace the per-ntp reconcilation fibers with a single background loop that runs a `reconciliation_pass()`. Delta notifications queue `ntp`s in `_pending` and wake the background loop. Each pass then takes the queued set and reconciles it with `max_concurrent_for_each()` bounded by `controller_backend_reconciliation_concurrency`.

Fixes more CI failure tickets than I can shake a stick at (I think)

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none
