### PR TITLE
serde/json: fix number parsing precision bugs

### DIFF
--- a/src/v/serde/json/detail/numeric.cc
+++ b/src/v/serde/json/detail/numeric.cc
@@ -163,8 +163,12 @@ size_t numeric_parser::advance(ss::temporary_buffer<char>& buf, result& err) {
                 if (_significand_digits < 17) {
                     _double_acc = _double_acc * 10
                                   + static_cast<unsigned>(buf[pos] - '0');
-                    _significand_digits += 1;
                     --_exp_frac;
+                    // Leading zeros carry no precision; only digits with a
+                    // nonzero prefix count against the significand budget.
+                    if (_double_acc > 0) {
+                        _significand_digits += 1;
+                    }
                 }
                 pos += 1;
                 continue;

--- a/src/v/serde/json/detail/numeric.cc
+++ b/src/v/serde/json/detail/numeric.cc
@@ -29,6 +29,12 @@
 
 namespace serde::json::detail {
 
+namespace {
+// Bound on |_exp_adjust| so the exponent arithmetic below cannot overflow
+// int. Reaching it takes a number with 10^8 digits; such input is rejected.
+constexpr int max_exp_adjust = 100'000'000;
+} // namespace
+
 size_t numeric_parser::advance(ss::temporary_buffer<char>& buf, result& err) {
     size_t pos = 0;
 
@@ -93,9 +99,15 @@ size_t numeric_parser::advance(ss::temporary_buffer<char>& buf, result& err) {
 
         case state::decimals_as_double:
             if (buf[pos] >= '0' && buf[pos] <= '9') {
-                _double_acc = _double_acc * 10
-                              + static_cast<unsigned>(buf[pos] - '0');
-                _significand_digits += 1;
+                // The significand is saturated (18-19 digits, more than a
+                // double can represent). Account for further integer digits
+                // in the scale instead to preserve the magnitude.
+                if (_exp_adjust >= max_exp_adjust) {
+                    err = result::invalid_json_string;
+                    _state = state::finished_with_error;
+                    return pos;
+                }
+                _exp_adjust += 1;
                 pos += 1;
                 continue;
             } else {
@@ -126,6 +138,8 @@ size_t numeric_parser::advance(ss::temporary_buffer<char>& buf, result& err) {
                 err = result::done;
                 if (_as_double) {
                     _state = state::finished_with_double;
+                    _double_acc = strtod_normal_precision(
+                      _double_acc, _exp_adjust);
                     if (_double_acc > std::numeric_limits<double>::max()) {
                         err = result::invalid_json_string;
                         _state = state::finished_with_error;
@@ -161,9 +175,14 @@ size_t numeric_parser::advance(ss::temporary_buffer<char>& buf, result& err) {
         case state::fractional_part:
             if (buf[pos] >= '0' && buf[pos] <= '9') {
                 if (_significand_digits < 17) {
+                    if (_exp_adjust <= -max_exp_adjust) {
+                        err = result::invalid_json_string;
+                        _state = state::finished_with_error;
+                        return pos;
+                    }
                     _double_acc = _double_acc * 10
                                   + static_cast<unsigned>(buf[pos] - '0');
-                    --_exp_frac;
+                    --_exp_adjust;
                     // Leading zeros carry no precision; only digits with a
                     // nonzero prefix count against the significand budget.
                     if (_double_acc > 0) {
@@ -181,7 +200,7 @@ size_t numeric_parser::advance(ss::temporary_buffer<char>& buf, result& err) {
                 _state = state::finished_with_double;
 
                 _double_acc = strtod_normal_precision(
-                  _double_acc, _exp_frac + _exp * (_exp_negative ? -1 : 1));
+                  _double_acc, _exp_adjust + _exp * (_exp_negative ? -1 : 1));
                 if (_double_acc > std::numeric_limits<double>::max()) {
                     err = result::invalid_json_string;
                     _state = state::finished_with_error;
@@ -203,13 +222,20 @@ size_t numeric_parser::advance(ss::temporary_buffer<char>& buf, result& err) {
             if (buf[pos] == '-') {
                 pos += 1;
                 _exp_negative = true;
-                _max_exp = (_exp_frac + 2147483639) / 10;
+                if (_exp_adjust > 0) {
+                    // Once the explicit exponent cancels the dropped integer
+                    // digits and another ~400 decimal places, the value is
+                    // guaranteed to underflow to zero.
+                    _max_exp = _exp_adjust + 400;
+                } else {
+                    _max_exp = (_exp_adjust + 2147483639) / 10;
+                }
             } else {
                 if (buf[pos] == '+') {
                     pos += 1;
                 }
 
-                _max_exp = 308 - _exp_frac;
+                _max_exp = 308 - _exp_adjust;
             }
             _state = state::exponent_first_digit;
             continue;
@@ -253,7 +279,7 @@ size_t numeric_parser::advance(ss::temporary_buffer<char>& buf, result& err) {
                 _state = state::finished_with_double;
 
                 _double_acc = strtod_normal_precision(
-                  _double_acc, _exp_frac + _exp * (_exp_negative ? -1 : 1));
+                  _double_acc, _exp_adjust + _exp * (_exp_negative ? -1 : 1));
                 if (_double_acc > std::numeric_limits<double>::max()) {
                     err = result::invalid_json_string;
                     _state = state::finished_with_error;

--- a/src/v/serde/json/detail/numeric.h
+++ b/src/v/serde/json/detail/numeric.h
@@ -113,7 +113,11 @@ private:
     bool _as_double{false};
     double _double_acc{0.0};
 
-    int _exp_frac = 0;
+    /// Decimal exponent of the accumulated significand relative to the
+    /// written digits: negative while consuming fraction digits, positive
+    /// when integer digits beyond the significand capacity are dropped and
+    /// accounted for in the scale instead.
+    int _exp_adjust = 0;
     int _max_exp = 0;
 
     bool _exp_negative{false};

--- a/src/v/serde/json/detail/strod.h
+++ b/src/v/serde/json/detail/strod.h
@@ -27,6 +27,8 @@
 
 #include "serde/json/detail/pow10.h"
 
+#include <limits>
+
 namespace serde::json::detail {
 
 inline double strod_fast_path(double significand, int exp) {
@@ -40,7 +42,12 @@ inline double strod_fast_path(double significand, int exp) {
 }
 
 inline double strtod_normal_precision(double d, int p) {
-    if (p < -308) {
+    if (p > 308) {
+        // Guaranteed overflow: p can only exceed 308 when the integer part
+        // alone has hundreds of digits, so the significand is non-zero.
+        // Callers reject values above double max.
+        return std::numeric_limits<double>::infinity();
+    } else if (p < -308) {
         // Prevent expSum < -308, making Pow10(p) = 0
         d = strod_fast_path(d, -308);
         d = strod_fast_path(d, p + 308);

--- a/src/v/serde/json/detail/tests/numeric_test.cc
+++ b/src/v/serde/json/detail/tests/numeric_test.cc
@@ -104,6 +104,13 @@ constexpr auto test_numerics = std::to_array<test_case>(
    test_case::valid("123.123", 123.123),
    test_case::valid("-123.123", -123.123),
 
+   // Leading zeros in the fraction must not consume the significand digit
+   // budget.
+   test_case::valid("0.000000000000000001234567", 1.234567e-18),
+   test_case::valid("-0.000000000000000001234567", -1.234567e-18),
+   test_case::valid("0.00000000000000000012345", 1.2345e-19),
+   test_case::valid("0.0001014244919119499", 0.0001014244919119499),
+
    // Large values
    test_case::valid(
      "9223372036854775807",

--- a/src/v/serde/json/detail/tests/numeric_test.cc
+++ b/src/v/serde/json/detail/tests/numeric_test.cc
@@ -512,3 +512,62 @@ TEST(numeric_parse, test_numeric_1E309) {
     test_parse_numeric_whole(
       test_case{input, numeric_parser::result::invalid_json_string, 310});
 }
+
+TEST(numeric_parse, test_numeric_big_integer_negative_exponent) {
+    // '1' followed by 309 '0', scaled back into range by the exponent.
+
+    std::string input = "1";
+    input.append(309, '0');
+    input.append("e-400");
+
+    test_parse_numeric_whole(test_case::valid(input, 1e-91));
+    test_parse_numeric_piecewise(test_case::valid(input, 1e-91));
+}
+
+TEST(numeric_parse, test_numeric_big_integer_exact_cancel) {
+    // '1' followed by 400 '0' with exponent -400 is exactly 1.
+
+    std::string input = "1";
+    input.append(400, '0');
+    input.append("e-400");
+
+    test_parse_numeric_whole(test_case::valid(input, 1.0));
+    test_parse_numeric_piecewise(test_case::valid(input, 1.0));
+}
+
+TEST(numeric_parse, test_numeric_big_integer_with_fraction) {
+    // The fraction after a saturated integer part carries no precision but
+    // must not disturb the magnitude.
+
+    std::string input = "1";
+    input.append(29, '0');
+    input.append(".5");
+
+    test_parse_numeric_whole(test_case::valid(input, 1e29));
+    test_parse_numeric_piecewise(test_case::valid(input, 1e29));
+}
+
+TEST(numeric_parse, test_numeric_big_integer_underflow) {
+    std::string input = "9";
+    input.append(444, '0');
+    input.append("e-617");
+
+    test_parse_numeric_whole(test_case::valid(input, 9e-173));
+
+    input = "1";
+    input.append(309, '0');
+    input.append("e-2000000000");
+
+    test_parse_numeric_whole(test_case::valid(input, 0.0));
+}
+
+TEST(numeric_parse, test_numeric_big_integer_overflow_with_fraction) {
+    // '1' followed by 400 '0' is too big for a double even with the ".5".
+
+    std::string input = "1";
+    input.append(400, '0');
+    input.append(".5,");
+
+    test_parse_numeric_whole(
+      test_case{input, numeric_parser::result::invalid_json_string, 403});
+}


### PR DESCRIPTION
Two bugs in the streaming JSON number parser, found by fuzzing it
against glibc strtod:

- Leading zeros in the fraction consumed the 17-digit significand
  budget, so `0.000000000000000001234567` parsed as `0.0`.
- Integer parts longer than ~309 digits overflowed the double
  accumulator to infinity, so a 310-digit integer with exponent
  `e-400` (~1e-91) was rejected as invalid JSON, and with exponents
  below -308 it silently parsed as `0.0`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## Release Notes

### Bug Fixes

* Fix JSON number parsing returning wrong values for fractions with
  many leading zeros and for numbers with very long integer parts.