### PR TITLE
config: publish default, bounds, and enterprise data in the config schema, plus a broker-scope dump

### DIFF
--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -262,6 +262,51 @@ public:
     virtual std::optional<std::string_view> units_name() const = 0;
     virtual bool is_nullable() const = 0;
     virtual bool is_array() const = 0;
+
+    /// Serialize this property's *default* value (not its current value) to
+    /// JSON, the same way to_json() serializes the current value. Used by
+    /// util::generate_json_schema (redpanda/admin/cluster_config_schema_util.cc)
+    /// to describe a property's default without a live instance.
+    virtual void to_json_default(
+      json::Writer<json::StringBuffer>& w, redact_secrets /*redact*/) const {
+        w.Null();
+    }
+
+    /// Lower/upper bound as a formatted string, for properties with no
+    /// runtime-queryable bound (i.e. anything not wrapping bounded_property).
+    /// Overridden by bounded_property<T>.
+    virtual std::optional<ss::sstring> minimum_as_string() const {
+        return std::nullopt;
+    }
+    virtual std::optional<ss::sstring> maximum_as_string() const {
+        return std::nullopt;
+    }
+
+    /// True for a property wrapped in config::enterprise<>. Overridden there.
+    virtual bool is_enterprise() const { return false; }
+
+    /// The community/sanctioned value used when there is no valid license.
+    /// Only meaningful when is_enterprise() is true. Overridden by
+    /// config::enterprise<P>.
+    virtual void to_json_enterprise_sanctioned(
+      json::Writer<json::StringBuffer>& w) const {
+        w.Null();
+    }
+
+    /// The restricted value(s) that require a license -- a single value or
+    /// an array, matching whichever shape config::enterprise<P> was
+    /// constructed with. Null when enterprise_restriction_is_dynamic() is
+    /// true (the restriction is a predicate function, not a static value).
+    virtual void to_json_enterprise_restricted(
+      json::Writer<json::StringBuffer>& w) const {
+        w.Null();
+    }
+
+    /// True when this property's enterprise restriction is a predicate
+    /// function rather than a static value or list of values -- i.e.
+    /// to_json_enterprise_restricted() cannot describe it and will write
+    /// null even though is_enterprise() is true.
+    virtual bool enterprise_restriction_is_dynamic() const { return false; }
     /**
      * Example of correct syntax for this property. In most cases, this value
      * should be accepted by the config api (JSON API/YAML parser) as a valid

--- a/src/v/config/bounded_property.h
+++ b/src/v/config/bounded_property.h
@@ -252,6 +252,33 @@ public:
         }
     }
 
+    // See base_property::minimum_as_string/maximum_as_string: exposes the
+    // bound this property already enforces at runtime (via _bounds) as a
+    // JSON-embeddable string, for callers with no live property instance to
+    // ask. Serialized through rjson_serialize, the same as to_json_default()
+    // serializes the default value -- not fmt::to_string(), which for a
+    // std::chrono duration appends a unit suffix ("1ms") that top-level
+    // callers who json-decode this string (matching how enum_values and
+    // default_value are documented to work) would fail to parse.
+    std::optional<ss::sstring> minimum_as_string() const override {
+        if (!_bounds.min.has_value()) {
+            return std::nullopt;
+        }
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> w(buf);
+        json::rjson_serialize(w, _bounds.min.value());
+        return ss::sstring(buf.GetString());
+    }
+    std::optional<ss::sstring> maximum_as_string() const override {
+        if (!_bounds.max.has_value()) {
+            return std::nullopt;
+        }
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> w(buf);
+        json::rjson_serialize(w, _bounds.max.value());
+        return ss::sstring(buf.GetString());
+    }
+
 private:
     I clamp_with_bounds(I val) {
         if (detail::bounds_checking_disabled()) {

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -194,6 +194,18 @@ public:
         }
     }
 
+    // See base_property::to_json_default: same serialization as to_json()
+    // above, but for _default instead of the live value.
+    void to_json_default(
+      json::Writer<json::StringBuffer>& w,
+      redact_secrets redact) const override {
+        if (is_secret() && redact == redact_secrets::yes) {
+            json::rjson_serialize(w, secret_placeholder);
+        } else {
+            json::rjson_serialize(w, _default);
+        }
+    }
+
     void set_value(std::any v) override {
         update_value(std::any_cast<value_type>(std::move(v)));
     }
@@ -1182,6 +1194,22 @@ concept Property = requires() {
 template<typename T>
 concept Array = detail::is_array<T>() && !reflection::is_std_optional<T>;
 
+// config::enterprise<P>'s restriction can be phrased over val_t (the
+// *unwrapped* element/inner type used for restriction checks), which is not
+// necessarily a type any property has ever needed to serialize before --
+// unlike T itself, which to_json()/to_json_default() already require to be
+// serializable for every property that compiles today.
+// config::sasl_mechanisms_override is one such restriction-only val_t with
+// no rjson_serialize overload. enterprise<P>::to_json_enterprise_restricted
+// uses this concept to check val_t before serializing it, so a type like
+// that reports enterprise_restriction_is_dynamic() instead of failing to
+// compile.
+template<typename T>
+concept json_serializable = requires(
+  json::Writer<json::StringBuffer>& w, const T& v) {
+    json::rjson_serialize(w, v);
+};
+
 } // namespace detail
 
 /**
@@ -1291,6 +1319,41 @@ public:
       , _restriction(std::move(restricted))
       , _sanctioned_value{sanctioned_value} {
         assert_no_sanctioned_conflict();
+    }
+
+    // See base_property::is_enterprise.
+    bool is_enterprise() const override { return true; }
+
+    // See base_property::to_json_enterprise_sanctioned/to_json_enterprise_restricted:
+    // exposes the same sanctioned/restricted values check_restricted() below
+    // already uses, for callers with no live property instance to ask.
+    void to_json_enterprise_sanctioned(
+      json::Writer<json::StringBuffer>& w) const override {
+        json::rjson_serialize(w, _sanctioned_value);
+    }
+
+    bool enterprise_restriction_is_dynamic() const override {
+        return std::holds_alternative<restrict_check_t>(_restriction);
+    }
+
+    void to_json_enterprise_restricted(
+      json::Writer<json::StringBuffer>& w) const override {
+        // Guarded on val_t (the element type) directly, not on
+        // val_container_t as a whole: the generic vector<T> serializer's
+        // body still calls rjson_serialize per element, so checking only
+        // the vector type would not catch a non-serializable element until
+        // that template's own instantiation -- one hard-error too late.
+        if constexpr (detail::json_serializable<val_t>) {
+            ss::visit(
+              _restriction,
+              [&w](const val_t& v) { json::rjson_serialize(w, v); },
+              [&w](const val_container_t& vals) {
+                  json::rjson_serialize(w, vals);
+              },
+              [&w](const restrict_check_t&) { w.Null(); });
+        } else {
+            w.Null();
+        }
     }
 
     // Needed because the following override shadows the rest of the overloads

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -251,6 +251,39 @@
           "type": "array",
           "items": {"type": "string"},
           "description": "List of legacy names for the property.  Property may be set using these names, but will always appear in GET requests via its primary name."
+        },
+        "default_value": {
+          "type": "string",
+          "description": "Default value, in string-ized form. Named default_value, not default, because 'default' is a reserved word in the generated C++ struct.",
+          "nullable": true
+        },
+        "minimum": {
+          "type": "string",
+          "description": "Lower bound, in string-ized form, for a bounded numeric property",
+          "nullable": true
+        },
+        "maximum": {
+          "type": "string",
+          "description": "Upper bound, in string-ized form, for a bounded numeric property",
+          "nullable": true
+        },
+        "is_enterprise": {
+          "type": "boolean",
+          "description": "Whether this property is wrapped in config::enterprise<> (may require a license to set to a restricted value)"
+        },
+        "enterprise_sanctioned_value": {
+          "type": "string",
+          "description": "The community/sanctioned value used when there is no valid license, in string-ized (JSON-encoded) form. Only meaningful when is_enterprise is true.",
+          "nullable": true
+        },
+        "enterprise_restricted_value": {
+          "type": "string",
+          "description": "The value or array of values that require a license, in string-ized (JSON-encoded) form. Null when enterprise_restriction_is_dynamic is true (the restriction is a predicate function, not a static value).",
+          "nullable": true
+        },
+        "enterprise_restriction_is_dynamic": {
+          "type": "boolean",
+          "description": "True when is_enterprise is true but the restriction is a predicate function rather than a static value or list of values, so enterprise_restricted_value cannot describe it."
         }
       }
     }

--- a/src/v/redpanda/admin/cluster_config_schema_util.cc
+++ b/src/v/redpanda/admin/cluster_config_schema_util.cc
@@ -128,3 +128,27 @@ util::generate_json_schema(const config::configuration& conf) {
       {ss::sstring("properties"), std::move(properties)}};
     return ss::json::stream_object(std::move(response));
 }
+
+// Same mechanism as generate_json_schema, for node (broker) configuration.
+// Factored out identically so downstream tools have one static, no-cluster
+// path for each scope they need, rather than only the cluster-scoped one.
+ss::json::json_return_type
+util::generate_node_config_json_schema(const config::node_config& conf) {
+    property_map properties;
+
+    conf.for_each([&properties](const config::base_property& p) {
+        if (p.is_hidden()) {
+            return;
+        }
+
+        auto [pm_i, inserted] = properties.emplace(
+          ss::sstring(p.name()),
+          ss::httpd::cluster_config_json::cluster_config_property_metadata());
+        vassert(inserted, "Emplace failed, duplicate property name?");
+        populate_property_metadata(pm_i->second, p);
+    });
+
+    std::map<ss::sstring, property_map> response = {
+      {ss::sstring("properties"), std::move(properties)}};
+    return ss::json::stream_object(std::move(response));
+}

--- a/src/v/redpanda/admin/cluster_config_schema_util.cc
+++ b/src/v/redpanda/admin/cluster_config_schema_util.cc
@@ -14,15 +14,99 @@
 
 #include <seastar/json/json_elements.hh>
 
+namespace {
+
+using property_map = std::map<
+  ss::sstring,
+  ss::httpd::cluster_config_json::cluster_config_property_metadata>;
+
+void populate_property_metadata(
+  ss::httpd::cluster_config_json::cluster_config_property_metadata& pm,
+  const config::base_property& p) {
+    pm.description = ss::sstring(p.desc());
+    pm.needs_restart = p.needs_restart();
+    pm.visibility = ss::sstring(config::to_string_view(p.get_visibility()));
+    pm.nullable = p.is_nullable();
+    pm.is_secret = p.is_secret();
+
+    if (p.is_array()) {
+        pm.type = "array";
+
+        auto items = ss::httpd::cluster_config_json::
+          cluster_config_property_metadata_items();
+        items.type = ss::sstring(p.type_name());
+        pm.items = items;
+    } else {
+        pm.type = ss::sstring(p.type_name());
+    }
+
+    auto enum_values = p.enum_values();
+    if (!enum_values.empty()) {
+        // In swagger, this field would just be called 'enum', but
+        // because we use C++ code generation for our structures,
+        // we cannot use that reserved word
+        pm.enum_values = enum_values;
+    }
+
+    const auto& example = p.example();
+    if (example.has_value()) {
+        pm.example = ss::sstring(example.value());
+    }
+
+    const auto& units = p.units_name();
+    if (units.has_value()) {
+        pm.units = ss::sstring(units.value());
+    }
+
+    std::vector<ss::sstring> aliases;
+    for (const auto& alias : p.aliases()) {
+        aliases.emplace_back(alias);
+    }
+    pm.aliases = aliases;
+
+    {
+        json::StringBuffer default_buf;
+        json::Writer<json::StringBuffer> default_writer(default_buf);
+        p.to_json_default(default_writer, config::redact_secrets::no);
+        pm.default_value = ss::sstring(default_buf.GetString());
+    }
+    if (auto min = p.minimum_as_string(); min.has_value()) {
+        pm.minimum = min.value();
+    }
+    if (auto max = p.maximum_as_string(); max.has_value()) {
+        pm.maximum = max.value();
+    }
+
+    pm.is_enterprise = p.is_enterprise();
+    if (p.is_enterprise()) {
+        {
+            json::StringBuffer sanctioned_buf;
+            json::Writer<json::StringBuffer> sanctioned_writer(
+              sanctioned_buf);
+            p.to_json_enterprise_sanctioned(sanctioned_writer);
+            pm.enterprise_sanctioned_value = ss::sstring(
+              sanctioned_buf.GetString());
+        }
+        pm.enterprise_restriction_is_dynamic
+          = p.enterprise_restriction_is_dynamic();
+        {
+            json::StringBuffer restricted_buf;
+            json::Writer<json::StringBuffer> restricted_writer(
+              restricted_buf);
+            p.to_json_enterprise_restricted(restricted_writer);
+            pm.enterprise_restricted_value = ss::sstring(
+              restricted_buf.GetString());
+        }
+    }
+}
+
+} // namespace
+
 // This is factored out to make it a separate binary that can generate schema
 // without bringing up a redpanda cluster. Down stream tools can make use of
 // this for config generation.
 ss::json::json_return_type
 util::generate_json_schema(const config::configuration& conf) {
-    using property_map = std::map<
-      ss::sstring,
-      ss::httpd::cluster_config_json::cluster_config_property_metadata>;
-
     property_map properties;
 
     conf.for_each([&properties](const config::base_property& p) {
@@ -37,48 +121,7 @@ util::generate_json_schema(const config::configuration& conf) {
           ss::sstring(p.name()),
           ss::httpd::cluster_config_json::cluster_config_property_metadata());
         vassert(inserted, "Emplace failed, duplicate property name?");
-
-        auto& pm = pm_i->second;
-        pm.description = ss::sstring(p.desc());
-        pm.needs_restart = p.needs_restart();
-        pm.visibility = ss::sstring(config::to_string_view(p.get_visibility()));
-        pm.nullable = p.is_nullable();
-        pm.is_secret = p.is_secret();
-
-        if (p.is_array()) {
-            pm.type = "array";
-
-            auto items = ss::httpd::cluster_config_json::
-              cluster_config_property_metadata_items();
-            items.type = ss::sstring(p.type_name());
-            pm.items = items;
-        } else {
-            pm.type = ss::sstring(p.type_name());
-        }
-
-        auto enum_values = p.enum_values();
-        if (!enum_values.empty()) {
-            // In swagger, this field would just be called 'enum', but
-            // because we use C++ code generation for our structures,
-            // we cannot use that reserved word
-            pm.enum_values = enum_values;
-        }
-
-        const auto& example = p.example();
-        if (example.has_value()) {
-            pm.example = ss::sstring(example.value());
-        }
-
-        const auto& units = p.units_name();
-        if (units.has_value()) {
-            pm.units = ss::sstring(units.value());
-        }
-
-        std::vector<ss::sstring> aliases;
-        for (const auto& alias : p.aliases()) {
-            aliases.emplace_back(alias);
-        }
-        pm.aliases = aliases;
+        populate_property_metadata(pm_i->second, p);
     });
 
     std::map<ss::sstring, property_map> response = {

--- a/src/v/redpanda/admin/cluster_config_schema_util.h
+++ b/src/v/redpanda/admin/cluster_config_schema_util.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "config/configuration.h"
+#include "config/node_config.h"
 
 #include <seastar/json/json_elements.hh>
 
@@ -23,5 +24,14 @@ namespace util {
  */
 ss::json::json_return_type
 generate_json_schema(const config::configuration& conf);
+
+/**
+ * @brief Generates json schema for node (broker-scoped) configuration.
+ * Same mechanism as generate_json_schema, for config::node_config instead
+ * of config::configuration.
+ * @return ss::json::json_return_type
+ */
+ss::json::json_return_type
+generate_node_config_json_schema(const config::node_config& conf);
 
 } // namespace util

--- a/src/v/rp_util/main.cc
+++ b/src/v/rp_util/main.cc
@@ -46,30 +46,42 @@ int run_seastar(std::function<ss::future<int>()> main) {
     }
 }
 
+ss::future<int> print_schema(ss::json::json_return_type schema) {
+    if (!schema._body_writer) {
+        vassert(
+          !schema._res.empty(),
+          "expected string if there is no body writer");
+        std::cout << schema._res << "\n";
+        return ss::as_ready_future(0);
+    }
+    vassert(
+      schema._res.empty(),
+      "expected empty string result if there is a body writer, got: {}",
+      schema._res);
+    auto buf = std::make_unique<iobuf>();
+    return schema._body_writer(make_iobuf_ref_output_stream(*buf.get()))
+      .then([buf = std::move(buf)]() -> int {
+          for (const auto& chunk : *buf) {
+              std::cout << std::string_view{chunk.get(), chunk.size()};
+          }
+          std::cout << "\n";
+          return 0;
+      });
+}
+
 int print_cluster_config_schema() {
     return run_seastar([]() -> ss::future<int> {
         auto cfg = config::make_config();
-        auto schema = util::generate_json_schema(*cfg);
-        if (!schema._body_writer) {
-            vassert(
-              !schema._res.empty(),
-              "expected string if there is no body writer");
-            std::cout << schema._res << "\n";
-            return ss::as_ready_future(0);
-        }
-        vassert(
-          schema._res.empty(),
-          "expected empty string result if there is a body writer, got: {}",
-          schema._res);
-        auto buf = std::make_unique<iobuf>();
-        return schema._body_writer(make_iobuf_ref_output_stream(*buf.get()))
-          .then([buf = std::move(buf)]() -> int {
-              for (const auto& chunk : *buf) {
-                  std::cout << std::string_view{chunk.get(), chunk.size()};
-              }
-              std::cout << "\n";
-              return 0;
-          });
+        return print_schema(util::generate_json_schema(*cfg));
+    });
+}
+
+// Same mechanism as print_cluster_config_schema, for node (broker)
+// configuration.
+int print_node_config_schema() {
+    return run_seastar([]() -> ss::future<int> {
+        config::node_config nc;
+        return print_schema(util::generate_node_config_json_schema(nc));
     });
 }
 } // namespace
@@ -90,6 +102,7 @@ int main(int ac, char* av[]) {
     desc.add_options()
       ("help", "Allowed options")
       ("config_schema_json", "Generates JSON schema for cluster configuration")
+      ("node_config_schema_json", "Generates JSON schema for node (broker) configuration")
       ("version", "Redpanda core version for this utility");
     // clang-format on
 
@@ -101,6 +114,8 @@ int main(int ac, char* av[]) {
         std::cout << desc << "\n";
     } else if (vm.count("config_schema_json")) {
         return print_cluster_config_schema();
+    } else if (vm.count("node_config_schema_json")) {
+        return print_node_config_schema();
     } else if (vm.count("version")) {
         std::cout << redpanda_version() << "\n";
     } else {


### PR DESCRIPTION
A few different tools outside this repo need complete, structured metadata about Redpanda's configuration properties, and right now they get it by re-parsing our C++ source or hand-maintaining a separate list that drifts out of date. The clearest example is our documentation generator, which walks the actual property definitions in `src/v/config/` with a custom parser to build the config reference pages — a real, ongoing maintenance burden every time a property definition uses a new pattern. The Redpanda Cloud console and internal tooling (including pandaparser) have similar needs and would benefit from the same structured source instead of each maintaining their own way of extracting this.

`util::generate_json_schema()` (used by both `rp_util --config_schema_json`, a small binary that can print this without starting a cluster, and the Admin API's `/v1/cluster_config/schema`) already publishes a lot of this: type, description, whether a restart is needed, and so on. But it stops short of the three things that actually require reading the C++ definitions today: what a property's *default* value is, what its *numeric bounds* are, and whether setting it *requires an enterprise license* (and if so, to what value). This PR adds all three, plus a broker-scope equivalent for `config::node_config` (today only cluster-wide `config::configuration` is covered).

None of this data is new — `property<T>` already knows its own default, `bounded_property<T>` already enforces its bounds at runtime, and `config::enterprise<P>` already knows whether a value is restricted and what the community-sanctioned value is. This just exposes what's already tracked, the same way `to_json()` already exposes the live value.

One extra safeguard: an enterprise restriction can be a single value, a list of values, or a predicate function. The first two are easy to serialize; a predicate can't be described statically. Rather than require every value type ever used in a restriction to support JSON serialization (some, like `sasl_mechanisms_override`, never have), a small compile-time check reports `enterprise_restriction_is_dynamic: true` for those cases instead of failing to build or guessing at a value.

## Testing

Built `rp_util` and ran both `--config_schema_json` and the new `--node_config_schema_json` against `dev`. All 570 cluster properties get a `default_value`; 118 get `minimum`, 64 get `maximum`; all 14 enterprise-gated cluster properties correctly report their sanctioned/restricted values (e.g. `audit_enabled`: sanctioned `false`, restricted `true`), and the 3 properties whose restriction is a predicate (`sasl_mechanisms`, `sasl_mechanisms_overrides`, `default_leaders_preference`) correctly report as dynamic rather than a wrong static value. The new broker-scope flag returns all 31 node properties with the same fields populated.

Also fed the real output of both flags through our docs generator's existing rendering templates (unmodified) as an end-to-end check — every property rendered correctly with no template changes needed on that side.

More background and the full investigation trail: [DOC-1828](https://redpandadata.atlassian.net/browse/DOC-1828).

## Backports Required

- [x] none - not a bug fix

## Release Notes

### Features

* `rp_util --config_schema_json` and the `/v1/cluster_config/schema` admin endpoint now include each property's default value, numeric bounds (where applicable), and enterprise-license restriction details.
* Added `rp_util --node_config_schema_json` to publish the same kind of schema for node (broker) configuration properties.

[DOC-1828]: https://redpandadata.atlassian.net/browse/DOC-1828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ