### PR TITLE
[CORE-16631] cluster_link: gate failover promotion on a producer ID barrier

### DIFF
--- a/src/v/cluster/cloud_metadata/producer_id_recovery_manager.h
+++ b/src/v/cluster/cloud_metadata/producer_id_recovery_manager.h
@@ -29,9 +29,15 @@ public:
 
     ss::future<cloud_metadata::error_outcome> recover() const;
 
-private:
+    /// The maximum producer ID over all partitions of every broker. Note:
+    /// a default-constructed (0) result means either "the maximum really is
+    /// 0" or "no producer state found anywhere" — producer ID 0 is valid, so
+    /// callers that must not miss an existing producer cannot treat 0 as
+    /// "nothing to do".
     ss::future<result<model::producer_id, cloud_metadata::error_outcome>>
     get_cluster_highest_pid() const;
+
+private:
     ss::future<result<model::producer_id, cloud_metadata::error_outcome>>
     get_node_highest_pid(const model::broker&) const;
 

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -124,6 +124,7 @@ redpanda_cc_library(
         ":errc",
         ":fwd",
         ":logger",
+        ":producer_id_barrier",
         ":utils",
         "//src/v/base",
         "//src/v/cluster",
@@ -308,6 +309,7 @@ redpanda_cc_library(
     deps = [
         ":errc",
         ":fwd",
+        ":producer_id_barrier",
         ":shadow_link_rpc_gen",
         "//src/v/base",
         "//src/v/cluster",

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -38,6 +38,28 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "producer_id_barrier",
+    srcs = [
+        "producer_id_barrier.cc",
+    ],
+    hdrs = [
+        "producer_id_barrier.h",
+    ],
+    implementation_deps = [
+        ":logger",
+        "//src/v/ssx:future_util",
+    ],
+    visibility = ["//src/v/cluster_link:__subpackages__"],
+    deps = [
+        ":errc",
+        "//src/v/base",
+        "//src/v/model",
+        "//src/v/ssx:semaphore",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "utils",
     srcs = [
         "utils.cc",

--- a/src/v/cluster_link/errc.cc
+++ b/src/v/cluster_link/errc.cc
@@ -88,6 +88,9 @@ struct error_category final : public std::error_category {
             return "target schema registry context is not empty";
         case errc::link_sr_verification_failed:
             return "schema registry verification failed";
+        case errc::producer_id_exhausted:
+            return "the cluster's highest producer ID is too close to the "
+                   "int64 maximum to advance the ID allocator";
         }
 
         return "(unknown error code)";

--- a/src/v/cluster_link/errc.h
+++ b/src/v/cluster_link/errc.h
@@ -54,6 +54,7 @@ enum class errc : int {
     link_sr_unreachable,
     link_sr_target_not_empty,
     link_sr_verification_failed,
+    producer_id_exhausted,
 };
 
 std::error_code make_error_code(errc) noexcept;

--- a/src/v/cluster_link/fwd.h
+++ b/src/v/cluster_link/fwd.h
@@ -14,6 +14,8 @@
 namespace cluster_link {
 class link;
 class manager;
+class producer_id_barrier;
+class producer_id_barrier_impl;
 class service;
 class sr_preflight_checker;
 } // namespace cluster_link

--- a/src/v/cluster_link/link_status_reconciler.cc
+++ b/src/v/cluster_link/link_status_reconciler.cc
@@ -13,7 +13,10 @@
 
 #include "cluster_link/deps.h"
 #include "cluster_link/logger.h"
+#include "cluster_link/producer_id_barrier.h"
 #include "ssx/future-util.h"
+
+#include <seastar/coroutine/as_future.hh>
 
 static constexpr auto reconciliation_interval = std::chrono::seconds{1};
 static constexpr auto mutation_timeout = std::chrono::seconds{5};
@@ -56,7 +59,11 @@ void link_status_reconciler::reconcile() {
             _reconcilers.emplace(
               link_id,
               std::make_unique<per_link_reconciler>(
-                *_link_registry, link_id, _controller_term, _as));
+                *_link_registry,
+                *_pid_barrier,
+                link_id,
+                _controller_term,
+                _as));
         }
     }
     // find all links that no longer exist and remove their reconcilers
@@ -83,10 +90,12 @@ void link_status_reconciler::reconcile() {
 
 link_status_reconciler::per_link_reconciler::per_link_reconciler(
   link_registry& registry,
+  producer_id_barrier& pid_barrier,
   model::id_t link_id,
   ::model::term_id term,
   ss::abort_source& as)
   : _registry(registry)
+  , _pid_barrier(pid_barrier)
   , _link_id(link_id)
   , _term(term) {
     _as_sub = as.subscribe([this] noexcept { _as.request_abort(); });
@@ -104,10 +113,11 @@ ss::future<> link_status_reconciler::per_link_reconciler::stop() noexcept {
     co_await _gate.close();
 }
 
-ss::future<> link_status_reconciler::per_link_reconciler::try_finish_failover(
-  const ::model::topic& topic) noexcept {
+ss::future<bool>
+link_status_reconciler::per_link_reconciler::is_ready_for_promotion(
+  const ::model::topic& topic) {
     if (_as.abort_requested()) {
-        co_return;
+        co_return false;
     }
     vlog(
       cllog.trace,
@@ -122,7 +132,7 @@ ss::future<> link_status_reconciler::per_link_reconciler::try_finish_failover(
           _link_id,
           topic,
           topic_report.error());
-        co_return;
+        co_return false;
     }
     // A topic is ready for promotion once every partition leader has been
     // reported in the health report at a link revision at least as new as
@@ -137,7 +147,7 @@ ss::future<> link_status_reconciler::per_link_reconciler::try_finish_failover(
           cllog.warn,
           "[{}] Inconsistent state detected, link revision does not exist",
           _link_id);
-        co_return;
+        co_return false;
     }
     chunked_hash_set<::model::partition_id> valid_partitions;
     auto local_update_revision = maybe_rev.value();
@@ -161,9 +171,48 @@ ss::future<> link_status_reconciler::per_link_reconciler::try_finish_failover(
           topic,
           valid_partitions.size(),
           topic_report->total_partitions);
+        co_return false;
+    }
+    co_return true;
+}
+
+ss::future<> link_status_reconciler::per_link_reconciler::collect_if_ready(
+  const ::model::topic& topic, chunked_vector<::model::topic>& ready) {
+    // try_finish_failover's caller used to be a noexcept path with no
+    // exception handling; keep that contract by converting failures of the
+    // readiness check into a logged skip.
+    auto f = co_await ss::coroutine::as_future(is_ready_for_promotion(topic));
+    if (f.failed()) {
+        auto eptr = f.get_exception();
+        vlog(
+          cllog.info,
+          "[{}] Readiness check for topic {} failed: {}",
+          _link_id,
+          topic,
+          eptr);
         co_return;
     }
+    if (f.get()) {
+        ready.push_back(topic);
+    }
+}
 
+ss::future<>
+link_status_reconciler::per_link_reconciler::promote_to_failed_over(
+  const ::model::topic& topic) {
+    // Idempotent across reconciliation retries (and forward-compatible with
+    // a forced promotion racing this one): a topic that already reached
+    // failed_over is a no-op success.
+    const auto& md = _registry.find_link_by_id(_link_id);
+    if (!md) {
+        co_return;
+    }
+    auto it = md->state.mirror_topics.find(topic);
+    if (
+      it == md->state.mirror_topics.end()
+      || it->second.status == model::mirror_topic_status::failed_over) {
+        co_return;
+    }
     auto result = co_await _registry.update_mirror_topic_state(
       _link_id,
       {.topic = topic, .status = model::mirror_topic_status::failed_over},
@@ -171,11 +220,12 @@ ss::future<> link_status_reconciler::per_link_reconciler::try_finish_failover(
     if (result != cluster::cluster_link::errc::success) {
         vlog(
           cllog.warn,
-          "[{}] Failed to transition topic {} to  state {}, error: {}",
+          "[{}] Failed to transition topic {} to state {}, error: {}",
           _link_id,
           topic,
           model::mirror_topic_status::failed_over,
           result);
+        co_return;
     }
     vlog(
       cllog.debug,
@@ -183,6 +233,38 @@ ss::future<> link_status_reconciler::per_link_reconciler::try_finish_failover(
       _link_id,
       topic,
       model::mirror_topic_status::failed_over);
+}
+
+void link_status_reconciler::per_link_reconciler::log_barrier_error(
+  errc ec, size_t topics) const {
+    switch (ec) {
+    case errc::service_shutting_down:
+        vlog(
+          cllog.debug,
+          "[{}] Producer ID barrier aborted by shutdown, leaving {} topic(s) "
+          "in failing_over",
+          _link_id,
+          topics);
+        return;
+    case errc::producer_id_exhausted:
+        vlog(
+          cllog.error,
+          "[{}] Producer ID space is exhausted; {} topic(s) cannot complete "
+          "failover. Force the failover with `rpk shadow delete --force` if "
+          "the mirrored data must be writable regardless.",
+          _link_id,
+          topics);
+        return;
+    default:
+        vlog(
+          cllog.info,
+          "[{}] Producer ID barrier failed with {}, leaving {} topic(s) in "
+          "failing_over until the next reconciliation",
+          _link_id,
+          ec,
+          topics);
+        return;
+    }
 }
 
 ss::future<>
@@ -203,10 +285,51 @@ link_status_reconciler::per_link_reconciler::reconcile_status_changes() {
                 pending_failover_topics.push_back(topic);
             }
         }
+        // Phase 1 — which topics pass the leader-report readiness check.
+        // Safe to collect from concurrent fibers: single shard, no
+        // scheduling point in push_back.
+        chunked_vector<::model::topic> ready;
         co_await ss::max_concurrent_for_each(
-          pending_failover_topics, 8, [this](const auto& topic) {
-              return try_finish_failover(topic);
+          pending_failover_topics, 8, [this, &ready](const auto& topic) {
+              return collect_if_ready(topic, ready);
           });
+        if (!ready.empty()) {
+            // Phase 2 — ONE cluster-wide barrier for the whole batch.
+            // Running it per topic would issue an all-broker scan and an
+            // allocator quorum write per topic, up to 8 concurrently. Every
+            // topic in `ready` was declared ready before this scan began,
+            // which is the ordering the barrier requires. The barrier is
+            // what guarantees a producer connecting to a promoted topic
+            // cannot be handed a producer ID colliding with mirrored
+            // idempotency state. Known residual: readiness proves the
+            // leaders applied failing_over, not that replicators drained, so
+            // mirrored producer IDs landing after the scan are only covered
+            // by the barrier's fixed margin.
+            auto barrier = co_await _pid_barrier.advance();
+            if (_as.abort_requested()) {
+                // The barrier is not tied to this reconciler's lifetime and
+                // its RPCs can outlive a controller leadership change.
+                // update_mirror_topic_state routes to the current leader, so
+                // without this check a stepped-down reconciler would promote
+                // on the new leader's behalf.
+                vlog(
+                  cllog.debug,
+                  "[{}] Reconciler stopped during the producer ID barrier, "
+                  "leaving {} topic(s) in failing_over",
+                  _link_id,
+                  ready.size());
+                co_return;
+            }
+            if (barrier.has_error()) {
+                log_barrier_error(barrier.error(), ready.size());
+            } else {
+                // Phase 3 — promote the batch.
+                co_await ss::max_concurrent_for_each(
+                  ready, 8, [this](const auto& topic) {
+                      return promote_to_failed_over(topic);
+                  });
+            }
+        }
         co_await ss::sleep_abortable(reconciliation_interval, _as);
     }
 }

--- a/src/v/cluster_link/link_status_reconciler.cc
+++ b/src/v/cluster_link/link_status_reconciler.cc
@@ -124,13 +124,13 @@ ss::future<> link_status_reconciler::per_link_reconciler::try_finish_failover(
           topic_report.error());
         co_return;
     }
-    // A topic can be promoted if all the partitions leaders have been reported
-    // in the health report
-    // and each such leader has seen the link update revision that the
-    // controller has seen for the link. The link revision check guarantees that
-    // the partition leader has unblocked the kafka API for the mirror topic
-    // after the failing_over state. This is not a fool proof check but is a
-    // reasonable heuristic.
+    // A topic is ready for promotion once every partition leader has been
+    // reported in the health report at a link revision at least as new as
+    // the controller's. The revision check establishes that the broker
+    // applied the failing_over state — which *initiates* replicator shutdown
+    // — it does NOT prove replicators have stopped, and it does NOT mean
+    // Kafka writes were unblocked; writes stay blocked until failed_over is
+    // applied (see cluster/cluster_link/frontend.cc is_topic_mutable).
     auto maybe_rev = _registry.get_last_update_revision(_link_id);
     if (!maybe_rev.has_value()) {
         vlog(

--- a/src/v/cluster_link/link_status_reconciler.h
+++ b/src/v/cluster_link/link_status_reconciler.h
@@ -11,7 +11,9 @@
 
 #pragma once
 
+#include "cluster_link/errc.h"
 #include "cluster_link/model/types.h"
+#include "container/chunked_vector.h"
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/gate.hh>
@@ -20,6 +22,7 @@ namespace cluster_link {
 
 class link;
 class link_registry;
+class producer_id_barrier;
 
 /**
  * Runs on controller leader shard and is responsible for reconciling links and
@@ -27,9 +30,12 @@ class link_registry;
  */
 class link_status_reconciler {
 public:
-    explicit link_status_reconciler(
-      link_registry* link_registry, ::model::term_id term)
+    link_status_reconciler(
+      link_registry* link_registry,
+      producer_id_barrier* pid_barrier,
+      ::model::term_id term)
       : _link_registry(link_registry)
+      , _pid_barrier(pid_barrier)
       , _controller_term(term) {}
 
     ss::future<> start() noexcept;
@@ -39,8 +45,12 @@ public:
 private:
     class per_link_reconciler {
     public:
-        explicit per_link_reconciler(
-          link_registry&, model::id_t, ::model::term_id, ss::abort_source&);
+        per_link_reconciler(
+          link_registry&,
+          producer_id_barrier&,
+          model::id_t,
+          ::model::term_id,
+          ss::abort_source&);
         ss::future<> stop() noexcept;
         void notify_changes();
 
@@ -48,9 +58,18 @@ private:
         ss::future<> reconcile_status_changes();
         bool has_pending_reconciliations() const;
 
-        ss::future<> try_finish_failover(const ::model::topic&) noexcept;
+        /// The pre-promotion readiness check: every partition leader has
+        /// been reported in the health report at the controller's link
+        /// revision. Converts its own failures into a logged `false`.
+        ss::future<bool> is_ready_for_promotion(const ::model::topic&);
+        ss::future<> collect_if_ready(
+          const ::model::topic&, chunked_vector<::model::topic>& ready);
+        ss::future<> promote_to_failed_over(const ::model::topic&);
+        void log_barrier_error(errc, size_t topics) const;
+
         ss::condition_variable _cv;
         link_registry& _registry;
+        producer_id_barrier& _pid_barrier;
         model::id_t _link_id;
         ::model::term_id _term;
         ss::gate _gate;
@@ -60,6 +79,7 @@ private:
     chunked_hash_map<model::id_t, std::unique_ptr<per_link_reconciler>>
       _reconcilers;
     link_registry* _link_registry;
+    producer_id_barrier* _pid_barrier;
     ::model::term_id _controller_term;
     ss::gate _gate;
     ss::abort_source _as;

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -93,6 +93,7 @@ manager::manager(
   std::unique_ptr<kafka_rpc_client_service> kafka_rpc_client_service,
   std::unique_ptr<members_table_provider> members_table_provider,
   std::unique_ptr<sr_preflight_checker> sr_preflight,
+  producer_id_barrier* pid_barrier,
   ss::sharded<features::feature_table>* feature_table,
   ss::lowres_clock::duration task_reconciler_interval,
   config::binding<int16_t> default_topic_replication,
@@ -112,6 +113,7 @@ manager::manager(
   , _kafka_rpc_client_service(std::move(kafka_rpc_client_service))
   , _members_table_provider(std::move(members_table_provider))
   , _sr_preflight(std::move(sr_preflight))
+  , _pid_barrier(pid_barrier)
   , _queue(
       scheduling_group,
       [](const std::exception_ptr& ex) {
@@ -1053,7 +1055,7 @@ ss::future<> manager::on_controller_leadership(::model::term_id term) {
     }
     if (!_link_status_reconciler) {
         _link_status_reconciler = std::make_unique<link_status_reconciler>(
-          _registry.get(), term);
+          _registry.get(), _pid_barrier, term);
         try {
             co_await _link_status_reconciler->start();
         } catch (const std::exception& e) {

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -31,6 +31,8 @@
 
 namespace cluster_link {
 
+class producer_id_barrier;
+
 /**
  * @brief Class used to manage cluster links
  *
@@ -59,6 +61,7 @@ public:
       std::unique_ptr<kafka_rpc_client_service> kafka_rpc_client_service,
       std::unique_ptr<members_table_provider> members_table_provider,
       std::unique_ptr<sr_preflight_checker> sr_preflight,
+      producer_id_barrier* pid_barrier,
       ss::sharded<features::feature_table>* feature_table,
       ss::lowres_clock::duration task_reconciler_interval,
       config::binding<int16_t> default_topic_replication,
@@ -249,6 +252,8 @@ private:
     std::unique_ptr<kafka_rpc_client_service> _kafka_rpc_client_service;
     std::unique_ptr<members_table_provider> _members_table_provider;
     std::unique_ptr<sr_preflight_checker> _sr_preflight;
+    // Owned by the service, which outlives the manager.
+    producer_id_barrier* _pid_barrier;
     ssx::work_queue _queue;
 
     chunked_vector<std::unique_ptr<task_factory>> _task_factories;

--- a/src/v/cluster_link/producer_id_barrier.cc
+++ b/src/v/cluster_link/producer_id_barrier.cc
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/dev/licenses/rcl.md
+ *
+ */
+
+#include "cluster_link/producer_id_barrier.h"
+
+#include "cluster_link/logger.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <limits>
+
+namespace cluster_link {
+
+void producer_id_barrier_impl::shutdown() noexcept {
+    if (!_as.abort_requested()) {
+        _as.request_abort();
+    }
+}
+
+ss::future<result<::model::producer_id, errc>>
+producer_id_barrier_impl::advance() noexcept {
+    if (_pid_exhausted) {
+        // Short-circuit rather than repeat an all-broker scan every
+        // reconciliation tick. Recovery from this state is a forced failover
+        // (`rpk shadow delete --force`).
+        co_return errc::producer_id_exhausted;
+    }
+    if (_as.abort_requested()) {
+        // The abortable semaphore wait below only aborts *waiters*; an
+        // immediately-available unit would let a post-shutdown advance run
+        // the scan anyway.
+        co_return errc::service_shutting_down;
+    }
+    auto f = co_await ss::coroutine::as_future(do_serialized_advance());
+    if (f.failed()) {
+        auto eptr = f.get_exception();
+        if (ssx::is_shutdown_exception(eptr)) {
+            vlog(cllog.debug, "Producer ID barrier aborted: {}", eptr);
+            co_return errc::service_shutting_down;
+        }
+        vlog(cllog.info, "Producer ID barrier failed: {}", eptr);
+        co_return errc::rpc_error;
+    }
+    auto res = f.get();
+    if (res.has_error() && res.error() == errc::producer_id_exhausted) {
+        _pid_exhausted = true;
+    }
+    co_return res;
+}
+
+ss::future<result<::model::producer_id, errc>>
+producer_id_barrier_impl::do_serialized_advance() {
+    // Single-flight: the barrier is cluster-scoped but every link runs its
+    // own reconciler fiber, so concurrent links would otherwise duplicate
+    // all-broker scans and equal-value resets — each an extra quorum write.
+    // Abortable so shutdown doesn't wait on queued barriers.
+    auto units = co_await ss::get_units(_sem, 1, _as);
+    co_return co_await do_advance();
+}
+
+ss::future<result<::model::producer_id, errc>>
+producer_id_barrier_impl::do_advance() {
+    auto scanned = co_await _ops->scan_highest_pid();
+    if (scanned.has_error()) {
+        co_return scanned.error();
+    }
+    // Always reset, including when the observed maximum is 0: producer ID 0
+    // is valid (a fresh allocator hands it out first), and the scan cannot
+    // distinguish it from "no producers found".
+    //
+    // The margin cushions a scan that undercounts slightly in this narrow
+    // window (producer IDs granted but not yet produced with, batches still
+    // in flight). It is NOT a general correctness guarantee and must not be
+    // read as covering an arbitrarily late batch.
+    constexpr int64_t barrier_margin = 1000;
+    auto raw = scanned.value()();
+    if (raw > std::numeric_limits<int64_t>::max() - barrier_margin) {
+        vlog(
+          cllog.error,
+          "Cluster highest producer ID {} is too close to the int64 maximum "
+          "to advance the ID allocator by {}",
+          raw,
+          barrier_margin);
+        co_return errc::producer_id_exhausted;
+    }
+    auto ec = co_await _ops->reset_next_id(
+      ::model::producer_id{raw + barrier_margin});
+    if (ec != errc::success) {
+        co_return ec;
+    }
+    co_return scanned.value();
+}
+
+} // namespace cluster_link

--- a/src/v/cluster_link/producer_id_barrier.h
+++ b/src/v/cluster_link/producer_id_barrier.h
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/dev/licenses/rcl.md
+ *
+ */
+
+#pragma once
+
+#include "base/outcome.h"
+#include "base/seastarx.h"
+#include "cluster_link/errc.h"
+#include "model/record.h"
+#include "ssx/semaphore.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+
+namespace cluster_link {
+
+/**
+ * \brief Confirms the local cluster's producer-ID allocator is advanced past
+ * every producer ID already present in this cluster's partitions.
+ *
+ * Mirrored batches carry the source cluster's producer IDs verbatim, and each
+ * partition's rm_stm rebuilds idempotency state from them on apply. Both
+ * clusters allocate producer IDs from zero, so once writes are released after
+ * a failover, a fresh producer could otherwise be handed an ID that collides
+ * with mirrored state and have its writes silently deduplicated against it.
+ * The failover path must therefore await this barrier before releasing
+ * writes.
+ */
+class producer_id_barrier {
+public:
+    producer_id_barrier() = default;
+    producer_id_barrier(const producer_id_barrier&) = delete;
+    producer_id_barrier(producer_id_barrier&&) = delete;
+    producer_id_barrier& operator=(const producer_id_barrier&) = delete;
+    producer_id_barrier& operator=(producer_id_barrier&&) = delete;
+    virtual ~producer_id_barrier() = default;
+
+    /// Returns the observed cluster-wide maximum on success. Any error means
+    /// the allocator was NOT confirmed advanced and the caller must not
+    /// promote. Never returns an exceptional future — the caller is a
+    /// noexcept path.
+    virtual ss::future<result<::model::producer_id, errc>>
+    advance() noexcept = 0;
+};
+
+/**
+ * \brief Default barrier: scan the cluster-wide maximum producer ID, then
+ * reset the allocator to that maximum plus a safety margin, awaited.
+ *
+ * Serializes concurrent callers (every link runs its own reconciler fiber)
+ * and caches producer-ID exhaustion as a terminal state so a hopeless
+ * all-broker scan is not repeated every reconciliation tick.
+ */
+class producer_id_barrier_impl final : public producer_id_barrier {
+public:
+    /**
+     * \brief The scan and reset operations the barrier drives.
+     *
+     * Injected so the barrier logic is unit-testable and this header stays
+     * free of the cluster/cloud_metadata dependency; the production adapter
+     * lives with the service, which owns the required frontends.
+     */
+    class ops {
+    public:
+        ops() = default;
+        ops(const ops&) = delete;
+        ops(ops&&) = delete;
+        ops& operator=(const ops&) = delete;
+        ops& operator=(ops&&) = delete;
+        virtual ~ops() = default;
+
+        /// Cluster-wide maximum producer ID over all partitions. The scan
+        /// cannot distinguish "no producers anywhere" from a real maximum of
+        /// 0 — producer ID 0 is valid, so the barrier resets in both cases.
+        virtual ss::future<result<::model::producer_id, errc>>
+        scan_highest_pid() = 0;
+
+        /// Advance the ID allocator so the next allocated producer ID is at
+        /// least the given one. Monotonic on the allocator side.
+        virtual ss::future<errc> reset_next_id(::model::producer_id) = 0;
+    };
+
+    explicit producer_id_barrier_impl(std::unique_ptr<ops> ops)
+      : _ops(std::move(ops)) {}
+
+    ss::future<result<::model::producer_id, errc>> advance() noexcept final;
+
+    /// Aborts current and queued advances; safe to call more than once.
+    void shutdown() noexcept;
+
+private:
+    ss::future<result<::model::producer_id, errc>> do_serialized_advance();
+    ss::future<result<::model::producer_id, errc>> do_advance();
+
+    std::unique_ptr<ops> _ops;
+    ssx::semaphore _sem{1, "cluster_link::pid_barrier"};
+    ss::abort_source _as;
+    // Terminal: producer IDs only grow and the allocator never moves
+    // backwards, so once the margin no longer fits below the int64 maximum a
+    // rescan cannot succeed.
+    bool _pid_exhausted{false};
+};
+
+} // namespace cluster_link

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -11,6 +11,7 @@
 
 #include "cluster_link/service.h"
 
+#include "cluster/cloud_metadata/producer_id_recovery_manager.h"
 #include "cluster/cluster_link/frontend.h"
 #include "cluster/controller.h"
 #include "cluster/controller_stm.h"
@@ -26,6 +27,7 @@
 #include "cluster_link/logger.h"
 #include "cluster_link/manager.h"
 #include "cluster_link/model/types.h"
+#include "cluster_link/producer_id_barrier.h"
 #include "cluster_link/replication/deps.h"
 #include "cluster_link/replication/mux_remote_consumer.h"
 #include "cluster_link/replication/types.h"
@@ -1271,6 +1273,51 @@ ss::future<> service::do_handle_enable_shadow_link_change() {
     }
 }
 
+namespace {
+
+/**
+ * \brief Production lower edge of the producer-ID barrier: scan through the
+ * cloud-metadata recovery manager's cluster-wide sweep, reset through the ID
+ * allocator frontend.
+ */
+class recovery_scan_pid_barrier_ops final
+  : public producer_id_barrier_impl::ops {
+public:
+    recovery_scan_pid_barrier_ops(
+      ss::sharded<cluster::members_table>& members_table,
+      ss::sharded<::rpc::connection_cache>& connections,
+      ss::sharded<cluster::id_allocator_frontend>& id_allocator)
+      : _recovery(members_table, connections, id_allocator)
+      , _id_allocator(&id_allocator) {}
+
+    ss::future<result<::model::producer_id, errc>> scan_highest_pid() final {
+        // NB: recover()'s "no producer IDs found" early return must not be
+        // mirrored here — producer ID 0 is valid and indistinguishable from
+        // "none found", and the barrier must reset in both cases.
+        auto res = co_await _recovery.get_cluster_highest_pid();
+        if (res.has_error()) {
+            co_return errc::rpc_error;
+        }
+        co_return res.value();
+    }
+
+    ss::future<errc> reset_next_id(::model::producer_id pid) final {
+        auto reply = co_await _id_allocator->local().reset_next_id(
+          pid, reset_timeout);
+        if (reply.ec != cluster::errc::success) {
+            co_return errc::rpc_error;
+        }
+        co_return errc::success;
+    }
+
+private:
+    static constexpr auto reset_timeout = std::chrono::seconds{10};
+    cluster::cloud_metadata::producer_id_recovery_manager _recovery;
+    ss::sharded<cluster::id_allocator_frontend>* _id_allocator;
+};
+
+} // namespace
+
 ss::future<> service::maybe_start_manager() {
     if (_manager) {
         co_return;
@@ -1280,6 +1327,14 @@ ss::future<> service::maybe_start_manager() {
     // handed in for the Schema Registry preflight checks.
     _schema_registry_dest = schema::registry::make_default(
       _schema_registry_api);
+
+    // Recreated on every manager start: shutdown() aborts it permanently, so
+    // a barrier that survived a previous manager stop cannot be reused.
+    _pid_barrier = std::make_unique<producer_id_barrier_impl>(
+      std::make_unique<recovery_scan_pid_barrier_ops>(
+        _controller->get_members_table(),
+        *_connections,
+        *_id_allocator_frontend));
 
     _manager = std::make_unique<manager>(
       _self,
@@ -1306,6 +1361,7 @@ ss::future<> service::maybe_start_manager() {
       members_table_provider::make_default(&_controller->get_members_table()),
       sr_preflight_checker::make_default(
         *_schema_registry_dest, source_sr_prober::make_default()),
+      _pid_barrier.get(),
       &_controller->get_feature_table(),
       30s, // Temporary until we have a proper configuration for this
       config::shard_local_cfg().default_topic_replications.bind(),
@@ -1389,6 +1445,11 @@ ss::future<> service::maybe_stop_manager() {
         co_return;
     }
     unregister_notifications();
+    // Unblock reconciler fibers waiting inside the barrier before stopping
+    // the manager, which waits on those fibers' gates.
+    if (_pid_barrier) {
+        _pid_barrier->shutdown();
+    }
     auto mgr = std::exchange(_manager, nullptr);
     co_await mgr->stop();
 }

--- a/src/v/cluster_link/service.h
+++ b/src/v/cluster_link/service.h
@@ -263,6 +263,9 @@ private:
     std::unique_ptr<schema::registry> _schema_registry_dest;
     std::unique_ptr<schema_registry_sync::source_reader_factory>
       _source_reader_factory;
+    // Owned here so it outlives the manager (whose reconciler holds a
+    // reference). Recreated on every manager start: shutdown() is one-way.
+    std::unique_ptr<producer_id_barrier_impl> _pid_barrier;
     std::unique_ptr<manager> _manager;
     std::vector<ss::deferred_action<ss::noncopyable_function<void()>>>
       _notification_cleanups;

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -16,6 +16,7 @@ redpanda_test_cc_library(
         "//src/v/cluster:types",
         "//src/v/cluster/cluster_link/tests:test_lib",
         "//src/v/cluster_link:impl",
+        "//src/v/cluster_link:producer_id_barrier",
         "//src/v/cluster_link:utils",
         "//src/v/cluster_link/replication/tests:deps_test_impl",
         "//src/v/config",
@@ -42,6 +43,26 @@ redpanda_cc_gtest(
         "//src/v/cluster_link:producer_id_barrier",
         "//src/v/model",
         "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "link_status_reconciler_test",
+    timeout = "short",
+    srcs = [
+        "link_status_reconciler_test.cc",
+    ],
+    deps = [
+        ":test_deps",
+        "//src/v/cluster:cluster_link_table",
+        "//src/v/cluster/cluster_link/tests:test_lib",
+        "//src/v/cluster_link:impl",
+        "//src/v/cluster_link:producer_id_barrier",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@abseil-cpp//absl/container:flat_hash_set",
         "@googletest//:gtest",
         "@seastar",
     ],

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -33,6 +33,21 @@ redpanda_test_cc_library(
 )
 
 redpanda_cc_gtest(
+    name = "producer_id_barrier_test",
+    timeout = "short",
+    srcs = [
+        "producer_id_barrier_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster_link:producer_id_barrier",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "link_test",
     timeout = "short",
     srcs = [

--- a/src/v/cluster_link/tests/deps.cc
+++ b/src/v/cluster_link/tests/deps.cc
@@ -108,6 +108,7 @@ ss::future<> cluster_link_manager_test_fixture::wire_up_and_start(
           return sr_preflight_checker::make_default(
             _fake_schema_registry, std::make_unique<fake_source_sr_prober>());
       }),
+      &_pid_barrier,
       &_feature_table,
       1s,
       _default_topic_replication.bind(),

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -15,6 +15,7 @@
 #include "cluster/cluster_link/table.h"
 #include "cluster/cluster_link/tests/utils.h"
 #include "cluster_link/manager.h"
+#include "cluster_link/producer_id_barrier.h"
 #include "cluster_link/replication/tests/deps_test_impl.h"
 #include "cluster_link/utils.h"
 #include "config/mock_property.h"
@@ -28,6 +29,7 @@
 #include "security/role.h"
 #include "security/role_store.h"
 
+#include <seastar/core/semaphore.hh>
 #include <seastar/util/defer.hh>
 
 using test_config_provider
@@ -97,6 +99,17 @@ public:
 private:
     ss::lowres_clock::duration _task_reconciler_interval;
     chunked_hash_map<model::name_t, link*> _links;
+};
+
+/// A producer-ID barrier that always succeeds, for fixtures that are not
+/// exercising failover promotion itself.
+class always_ok_pid_barrier final : public producer_id_barrier {
+public:
+    ss::future<result<::model::producer_id, errc>> advance() noexcept final {
+        ++calls;
+        co_return ::model::producer_id{0};
+    }
+    int calls{0};
 };
 
 class test_link_registry : public link_registry {
@@ -264,12 +277,19 @@ public:
 private:
     ss::future<::cluster::cluster_link::errc>
     apply_update(::model::record_batch&& batch) {
+        // The real table is only ever mutated by the controller STM's
+        // strictly sequential applies; its copy-modify-swap suspends and
+        // loses updates under concurrent callers, so serialize here to match
+        // the production contract.
+        auto units = co_await ss::get_units(_apply_units, 1);
         auto ec = co_await _table->apply_update(std::move(batch));
         vassert(
           ec.category() == cluster::cluster_link::error_category(),
           "Unexpected error category");
         co_return ::cluster::cluster_link::errc(ec.value());
     }
+
+    ss::semaphore _apply_units{1};
 
     cluster::cluster_link::table* _table;
     ::model::offset _last_offset{0};
@@ -817,6 +837,7 @@ private:
     test_kafka_rpc_client_service* _tkrcs{nullptr};
     fake_members_table_provider* _fmtp{nullptr};
     schema::fake_registry _fake_schema_registry;
+    always_ok_pid_barrier _pid_barrier;
     ss::sharded<manager> _manager;
     ss::sharded<features::feature_table> _feature_table;
     config::mock_property<int16_t> _default_topic_replication{1};

--- a/src/v/cluster_link/tests/link_status_reconciler_test.cc
+++ b/src/v/cluster_link/tests/link_status_reconciler_test.cc
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/link_status_reconciler.h"
+#include "cluster_link/producer_id_barrier.h"
+#include "cluster_link/tests/deps.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+
+#include <absl/container/flat_hash_set.h>
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+namespace cluster_link::tests {
+namespace {
+
+static const auto link_name = model::name_t("test_link");
+
+class fake_pid_barrier final : public producer_id_barrier {
+public:
+    ss::future<result<::model::producer_id, errc>> advance() noexcept final {
+        ++calls;
+        if (block) {
+            co_await block->get_future();
+            block.reset();
+        }
+        co_return next_result;
+    }
+
+    int calls{0};
+    result<::model::producer_id, errc> next_result{::model::producer_id{0}};
+    // When set, the next advance() parks until the promise is resolved,
+    // letting tests race reconciler shutdown against an in-flight barrier.
+    std::optional<ss::promise<>> block;
+};
+
+/// A registry whose health report declares every partition leader ready,
+/// except for explicitly held-back topics.
+class ready_report_registry final : public test_link_registry {
+public:
+    using test_link_registry::test_link_registry;
+
+    ss::future<std::expected<
+      ::cluster_link::model::aggregated_shadow_topic_report,
+      errc>>
+    shadow_topic_report(
+      const model::id_t& id, const ::model::topic& topic) override {
+        ::cluster_link::model::aggregated_shadow_topic_report report;
+        report.total_partitions = 1;
+        if (not_ready_topics.contains(topic)) {
+            // No leaders reported: the readiness check must hold this topic
+            // back.
+            co_return report;
+        }
+        auto rev = get_last_update_revision(id);
+        ::cluster_link::model::aggregated_shadow_topic_report::broker_report
+          broker{
+            .broker = ::model::node_id{0},
+            .link_update_revision = rev.value_or(::model::revision_id{0}),
+        };
+        broker.leaders.push_back({.partition = ::model::partition_id{0}});
+        report.brokers.push_back(std::move(broker));
+        co_return report;
+    }
+
+    absl::flat_hash_set<::model::topic> not_ready_topics;
+};
+
+} // namespace
+
+class link_status_reconciler_test : public seastar_test {
+public:
+    ss::future<> SetUpAsync() override {
+        co_await _table.start();
+        _registry = std::make_unique<ready_report_registry>(&_table.local());
+        _reconciler = std::make_unique<link_status_reconciler>(
+          _registry.get(), &_barrier, ::model::term_id{1});
+        co_await _reconciler->start();
+
+        co_await upsert_link(
+          model::metadata{
+            .name = link_name, .uuid = model::uuid_t(::uuid_t::create())});
+        auto ids = _registry->get_all_link_ids();
+        ASSERT_EQ_CORO(ids.size(), 1);
+        _link_id = ids[0];
+    }
+
+    ss::future<> TearDownAsync() override {
+        if (_reconciler) {
+            co_await _reconciler->stop();
+            _reconciler.reset();
+        }
+        _registry.reset();
+        co_await _table.stop();
+    }
+
+    ss::future<> upsert_link(model::metadata md) {
+        auto id = model::id_t(_next_link_id++);
+        return ss::do_with(
+          id, std::move(md), [this](model::id_t& id, model::metadata& md) {
+              return _table.invoke_on_all([id, &md](
+                                            cluster::cluster_link::table& t) {
+                  return md.copy().then([id, &t](model::metadata md) {
+                      return t
+                        .apply_update(
+                          cluster::cluster_link::testing::create_upsert_command(
+                            ::model::offset{id()}, std::move(md)))
+                        .then([](std::error_code ec) {
+                            vassert(
+                              ec.value() == 0,
+                              "failed to upsert link: {}",
+                              ec.message());
+                        });
+                  });
+              });
+          });
+    }
+
+    ss::future<> add_mirror_topic(const ::model::topic& topic) {
+        model::mirror_topic_metadata tpmd{
+          .status = model::mirror_topic_status::active,
+          .source_topic_name = topic,
+          .destination_topic_id = ::model::topic_id{::uuid_t::create()},
+          .partition_count = 1,
+          .replication_factor = 1,
+        };
+        auto batch
+          = cluster::cluster_link::testing::create_add_mirror_topic_command(
+            _link_id,
+            model::add_mirror_topic_cmd{
+              .topic = topic, .metadata = std::move(tpmd)});
+        auto ec = co_await _table.local().apply_update(std::move(batch));
+        vassert(
+          ec.value() == 0, "failed to add mirror topic: {}", ec.message());
+    }
+
+    ss::future<> start_failover() {
+        auto ec = co_await _registry->failover_link_topics(_link_id, 5s);
+        ASSERT_EQ_CORO(ec, cluster::cluster_link::errc::success);
+    }
+
+    model::mirror_topic_status status_of(const ::model::topic& topic) {
+        auto topics = _registry->get_mirror_topics_for_link(_link_id);
+        vassert(topics.has_value(), "link disappeared");
+        auto it = topics->find(topic);
+        vassert(it != topics->end(), "topic disappeared");
+        return it->second.status;
+    }
+
+protected:
+    ss::sharded<cluster::cluster_link::table> _table;
+    std::unique_ptr<ready_report_registry> _registry;
+    fake_pid_barrier _barrier;
+    std::unique_ptr<link_status_reconciler> _reconciler;
+    model::id_t _link_id;
+    int _next_link_id{1};
+};
+
+TEST_F_CORO(link_status_reconciler_test, barrier_error_blocks_promotion) {
+    const auto topic = ::model::topic("topic-a");
+    co_await add_mirror_topic(topic);
+    co_await start_failover();
+    _barrier.next_result = errc::rpc_error;
+
+    _reconciler->reconcile();
+    co_await ss::sleep(2500ms);
+
+    // The readiness check passes, so the barrier is being consulted — and
+    // its failure must leave the topic unpromoted.
+    ASSERT_GE_CORO(_barrier.calls, 1);
+    ASSERT_EQ_CORO(status_of(topic), model::mirror_topic_status::failing_over);
+
+    // The next successful barrier lets the retrying reconciler promote.
+    _barrier.next_result = ::model::producer_id{0};
+    co_await ::tests::cooperative_spin_wait_with_timeout(10s, [&] {
+        return status_of(topic) == model::mirror_topic_status::failed_over;
+    });
+}
+
+TEST_F_CORO(link_status_reconciler_test, one_barrier_call_promotes_batch) {
+    const auto topic_a = ::model::topic("topic-a");
+    const auto topic_b = ::model::topic("topic-b");
+    co_await add_mirror_topic(topic_a);
+    co_await add_mirror_topic(topic_b);
+    co_await start_failover();
+
+    _reconciler->reconcile();
+    co_await ::tests::cooperative_spin_wait_with_timeout(10s, [&] {
+        return status_of(topic_a) == model::mirror_topic_status::failed_over
+               && status_of(topic_b) == model::mirror_topic_status::failed_over;
+    });
+    // Both ready topics went through a single cluster-wide barrier.
+    ASSERT_EQ_CORO(_barrier.calls, 1);
+}
+
+TEST_F_CORO(link_status_reconciler_test, not_ready_topics_are_excluded) {
+    const auto topic_a = ::model::topic("topic-a");
+    const auto topic_b = ::model::topic("topic-b");
+    co_await add_mirror_topic(topic_a);
+    co_await add_mirror_topic(topic_b);
+    _registry->not_ready_topics.insert(topic_b);
+    co_await start_failover();
+
+    _reconciler->reconcile();
+    co_await ::tests::cooperative_spin_wait_with_timeout(10s, [&] {
+        return status_of(topic_a) == model::mirror_topic_status::failed_over;
+    });
+    ASSERT_EQ_CORO(
+      status_of(topic_b), model::mirror_topic_status::failing_over);
+
+    // Later ticks have nothing ready, so the barrier is not re-run for the
+    // held-back topic.
+    auto calls_after_promotion = _barrier.calls;
+    co_await ss::sleep(2500ms);
+    ASSERT_EQ_CORO(_barrier.calls, calls_after_promotion);
+    ASSERT_EQ_CORO(
+      status_of(topic_b), model::mirror_topic_status::failing_over);
+}
+
+TEST_F_CORO(link_status_reconciler_test, stop_during_barrier_blocks_promotion) {
+    const auto topic = ::model::topic("topic-a");
+    co_await add_mirror_topic(topic);
+    co_await start_failover();
+    // Park the barrier so reconciler shutdown (the stepdown path) races an
+    // in-flight advance().
+    _barrier.block.emplace();
+
+    _reconciler->reconcile();
+    co_await ::tests::cooperative_spin_wait_with_timeout(
+      10s, [&] { return _barrier.calls == 1; });
+
+    // Begin shutdown while the barrier is still in flight, then let the
+    // barrier complete successfully. The stopped reconciler must not act on
+    // the result.
+    auto stop_fut = _reconciler->stop();
+    _barrier.block->set_value();
+    co_await std::move(stop_fut);
+    _reconciler.reset();
+
+    ASSERT_EQ_CORO(status_of(topic), model::mirror_topic_status::failing_over);
+}
+
+TEST_F_CORO(link_status_reconciler_test, no_pending_topics_no_barrier) {
+    const auto topic = ::model::topic("topic-a");
+    co_await add_mirror_topic(topic);
+
+    _reconciler->reconcile();
+    co_await ss::sleep(1500ms);
+
+    ASSERT_EQ_CORO(_barrier.calls, 0);
+    ASSERT_EQ_CORO(status_of(topic), model::mirror_topic_status::active);
+}
+
+} // namespace cluster_link::tests

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -151,6 +151,7 @@ protected:
     std::unique_ptr<fake_partition_manager_proxy> _partition_manager_proxy;
     ss::sharded<table> _table;
 
+    always_ok_pid_barrier _pid_barrier;
     std::unique_ptr<manager> _manager;
     schema::fake_registry _fake_schema_registry;
     config::mock_property<int16_t> _default_topic_replication{3};
@@ -219,6 +220,7 @@ public:
           std::make_unique<fake_members_table_provider>(),
           sr_preflight_checker::make_default(
             _fake_schema_registry, std::move(sr_prober)),
+          &_pid_barrier,
           nullptr,
           task_reconciler_interval,
           _default_topic_replication.bind(),
@@ -469,6 +471,7 @@ public:
           std::make_unique<fake_members_table_provider>(),
           sr_preflight_checker::make_default(
             _fake_schema_registry, std::make_unique<fake_source_sr_prober>()),
+          &_pid_barrier,
           nullptr,
           task_reconciler_interval,
           _default_topic_replication.bind(),

--- a/src/v/cluster_link/tests/producer_id_barrier_test.cc
+++ b/src/v/cluster_link/tests/producer_id_barrier_test.cc
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/producer_id_barrier.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <stdexcept>
+
+namespace cluster_link::tests {
+
+namespace {
+
+class fake_ops final : public producer_id_barrier_impl::ops {
+public:
+    ss::future<result<::model::producer_id, errc>> scan_highest_pid() final {
+        ++scans;
+        if (scan_throws) {
+            throw std::runtime_error("scan failure");
+        }
+        co_return scan_result;
+    }
+
+    ss::future<errc> reset_next_id(::model::producer_id pid) final {
+        ++resets;
+        last_reset = pid;
+        co_return reset_result;
+    }
+
+    int scans{0};
+    int resets{0};
+    ::model::producer_id last_reset{};
+    result<::model::producer_id, errc> scan_result{::model::producer_id{0}};
+    errc reset_result{errc::success};
+    bool scan_throws{false};
+};
+
+struct barrier_under_test {
+    barrier_under_test() {
+        auto o = std::make_unique<fake_ops>();
+        ops = o.get();
+        barrier = std::make_unique<producer_id_barrier_impl>(std::move(o));
+    }
+    fake_ops* ops;
+    std::unique_ptr<producer_id_barrier_impl> barrier;
+};
+
+} // namespace
+
+TEST_CORO(producer_id_barrier, resets_even_when_scanned_max_is_zero) {
+    // Producer ID 0 is valid and indistinguishable from "no producers
+    // found"; the barrier must reset in both cases.
+    barrier_under_test t;
+    auto res = co_await t.barrier->advance();
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value(), ::model::producer_id{0});
+    ASSERT_EQ_CORO(t.ops->resets, 1);
+    ASSERT_EQ_CORO(t.ops->last_reset, ::model::producer_id{1000});
+}
+
+TEST_CORO(producer_id_barrier, returns_scanned_max_and_adds_margin) {
+    barrier_under_test t;
+    t.ops->scan_result = ::model::producer_id{41};
+    auto res = co_await t.barrier->advance();
+    ASSERT_TRUE_CORO(res.has_value());
+    ASSERT_EQ_CORO(res.value(), ::model::producer_id{41});
+    ASSERT_EQ_CORO(t.ops->last_reset, ::model::producer_id{1041});
+}
+
+TEST_CORO(producer_id_barrier, near_overflow_is_terminal_exhaustion) {
+    barrier_under_test t;
+    t.ops->scan_result = ::model::producer_id{
+      std::numeric_limits<int64_t>::max() - 1};
+    auto res = co_await t.barrier->advance();
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), errc::producer_id_exhausted);
+    ASSERT_EQ_CORO(t.ops->resets, 0);
+    // Terminal and cached: a second advance must not rescan.
+    auto again = co_await t.barrier->advance();
+    ASSERT_TRUE_CORO(again.has_error());
+    ASSERT_EQ_CORO(again.error(), errc::producer_id_exhausted);
+    ASSERT_EQ_CORO(t.ops->scans, 1);
+}
+
+TEST_CORO(producer_id_barrier, scan_error_means_no_reset) {
+    barrier_under_test t;
+    t.ops->scan_result = errc::rpc_error;
+    auto res = co_await t.barrier->advance();
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), errc::rpc_error);
+    ASSERT_EQ_CORO(t.ops->resets, 0);
+    // Not terminal: a later attempt scans again.
+    auto again = co_await t.barrier->advance();
+    ASSERT_TRUE_CORO(again.has_error());
+    ASSERT_EQ_CORO(t.ops->scans, 2);
+}
+
+TEST_CORO(producer_id_barrier, reset_error_is_not_success) {
+    barrier_under_test t;
+    t.ops->reset_result = errc::rpc_error;
+    auto res = co_await t.barrier->advance();
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), errc::rpc_error);
+}
+
+TEST_CORO(producer_id_barrier, exceptions_become_error_codes) {
+    barrier_under_test t;
+    t.ops->scan_throws = true;
+    // Must not surface as an exceptional future — the caller is a noexcept
+    // path.
+    auto res = co_await t.barrier->advance();
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), errc::rpc_error);
+}
+
+TEST_CORO(producer_id_barrier, shutdown_aborts_advances) {
+    barrier_under_test t;
+    t.barrier->shutdown();
+    auto res = co_await t.barrier->advance();
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), errc::service_shutting_down);
+    ASSERT_EQ_CORO(t.ops->scans, 0);
+}
+
+} // namespace cluster_link::tests

--- a/src/v/redpanda/admin/services/shadow_link/err.cc
+++ b/src/v/redpanda/admin/services/shadow_link/err.cc
@@ -59,6 +59,7 @@ void handle_error(cluster_link::errc err, ss::sstring info) {
     case cluster_link::errc::topic_mirrored_by_other_link:
         throw serde::pb::rpc::already_exists_exception(std::move(info));
     case cluster_link::errc::link_limit_reached:
+    case cluster_link::errc::producer_id_exhausted:
         throw serde::pb::rpc::resource_exhausted_exception(std::move(info));
     }
 }


### PR DESCRIPTION
A shadow-link topic promoted to `failed_over` can silently lose the first writes it receives. Mirrored batches carry the source cluster's producer IDs verbatim and each partition's `rm_stm` rebuilds idempotency state from them on apply, while both clusters allocate producer IDs from zero. The guard that advances the target's allocator past the mirrored range (`maybe_sync_pid`) lives on the replication data path: on a shadow cluster it is the first-ever user of the ID allocator, so it also pays for the allocator partition's creation and leader election inside its own timeout, its retry loop dies when `failing_over` stops the replicators, and the failover state machine never consults it. When the reset loses that race, the first post-failover producer draws a colliding `<producer_id, epoch>`, its sequences 0..N match mirrored finished requests, and the broker acks with the original batches' offsets without appending — silent data loss an ordinary producer cannot detect.

Root-caused from CI artifacts of build 88537 (producer log shows acked offsets *below* the correct log-end baseline; target broker logs show `failed_over` applied at 14:04:41,598 while the allocator's first leader election completed at 14:04:42,003 and `InitProducerId` returned the colliding `producer_id=1` at 14:04:42,082). All ~47 occurrences of the flake share the byte-identical `sent=4 acked=2 bad_offsets=2 restarts=1` signature this mechanism predicts.

This PR makes the `failing_over -> failed_over` transition await a producer ID barrier: scan the cluster-wide maximum producer ID (reusing the pre-existing `producer_id_recovery_manager` sweep and its already-shipped `highest_producer_id` RPC, so mixed-version clusters work), then an awaited `reset_next_id(max + margin)`. Barrier failure leaves topics in `failing_over` — writes stay blocked — and retries on the next reconciliation tick. One barrier runs per batch of ready topics, callers are serialized across links, and producer ID exhaustion is a cached terminal state surfaced as a new `producer_id_exhausted` error code.

Known residual limits, deliberate and documented in-code: readiness proves the leaders applied `failing_over`, not that replicators drained, so late mirrored producer IDs are only covered by the barrier's fixed margin; and a partition leader change between the scan and promotion can admit a higher ID. Closing those fully needs a write-release-side guard (the leader validating the allocator against its own `highest_producer_id()` before accepting produce) — follow-up material. The escape hatch for a barrier that cannot complete is the existing `DeleteShadowLinkRequest.force` path, which bypasses the reconciler entirely.

`test_producer_ids_failover` becomes a genuine regression test with no python changes: `wait_for_link_failover()` waits for `failed_over`, which now implies the barrier completed.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Bug Fixes

* Shadow link failover now waits until the cluster's producer ID allocator is confirmed to be advanced past every producer ID carried in mirrored data before topics become writable. Previously the first producers connecting right after failover could be assigned a producer ID colliding with mirrored idempotency state and have their writes silently discarded as duplicates.