### PR TITLE
config: document CPU cost of schema ID validation

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3963,7 +3963,9 @@ configuration::configuration(ctor_key)
       "Associated topic properties cannot be modified. * `redpanda`: Schema "
       "validation is enabled. Only Redpanda topic properties are accepted. * "
       "`compat`: Schema validation is enabled. Both Redpanda and compatible "
-      "topic properties are accepted.",
+      "topic properties are accepted. Enabling validation causes message "
+      "batches on configured topics to be decompressed for schema ID checks, "
+      "which can increase CPU load. Monitor CPU utilization after enabling.",
       meta{
         .needs_restart = needs_restart::no,
         .visibility = visibility::user,


### PR DESCRIPTION
Fixes #31596

Add the CPU cost of schema ID validation to the property metadata so it is
visible in rpk, the Admin API schema, and Console consumers. Validation
decompresses message batches on configured topics for schema ID checks,
which can increase CPU load.

## Backports Required

- [x] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

* The `enable_schema_id_validation` description now calls out the CPU impact
  of enabling validation.

## Release Notes

* none