### PR TITLE
kafka/schemata: tagged-field codegen fixes

### DIFF
--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1558,6 +1558,10 @@ if ({{ cond }}) {
 {%- endmacro %}
 
 {% macro tag_decoder_impl(tag_definitions, obj = "") %}
+{%- set tf = "unknown_tags" %}
+{%- if obj != "" %}
+{%- set tf = obj + '.unknown_tags' %}
+{%- endif %}
 /// Tags decoding section
 auto num_tags = reader.read_unsigned_varint();
 while(num_tags-- > 0) {
@@ -1565,15 +1569,22 @@ while(num_tags-- > 0) {
     auto sz = reader.read_unsigned_varint(); // size
     switch(tag){
 {%- for tdef in tag_definitions %}
+{%- set e, cond = tdef.tagged_versions()._guard() %}
     case {{ tdef.tag() }}:
+{%- if e == tdef.tagged_versions().guard_enum.GUARD %}
+        if ({{ cond }}) {
+{{- field_decoder(tdef, (field_decoder, tag_decoder), obj) | indent | indent | indent }}
+        } else {
+            // The tag only carries this field from a later version: below
+            // it, preserve the payload as an unknown tag.
+            reader.consume_unknown_tag({{ tf }}, tag, sz);
+        }
+{%- else %}
 {{- field_decoder(tdef, (field_decoder, tag_decoder), obj) | indent | indent }}
+{%- endif %}
         break;
 {%- endfor %}
     default:
-{%- set tf = "unknown_tags" %}
-{%- if obj != "" %}
-{%- set tf = obj + '.unknown_tags' %}
-{%- endif %}
         reader.consume_unknown_tag({{ tf }}, tag, sz);
     }
 }

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1534,7 +1534,7 @@ if ({{ cond }}) {
 });
 {%- else %}
 {%- if field.type().is_struct -%}
-{{- struct_serde(field.type(), methods, "v." ~ field.name) -}}
+{{- struct_serde(field.type(), methods, fname) -}}
 {%- else -%}
 {%- set decoder, named_type = field.decoder(flex) %}
 {%- if named_type == None %}
@@ -1619,7 +1619,7 @@ if (!{{ fname }}.empty()) {
     {{ vec }}.push_back({{ tdef.tag() }});
 }
 {%- elif tdef.type().is_struct  %}
-if ({{ fname }} != {{ tdef.type().name }}{}) {
+if ({{ fname }} != decltype({{ fname }}){}) {
     {{ vec }}.push_back({{ tdef.tag() }});
 }
 {%- elif tdef.default_value() != "" %}
@@ -1653,7 +1653,8 @@ for(uint32_t tag : to_encode) {
 {%- for tdef in tag_definitions %}
     case {{ tdef.tag() }}:
 {%- if tdef.type().is_struct -%}
-{{- struct_serde(tdef.type(), (field_encoder, tag_encoder), obj ~ "." ~ tdef.name, "rw") | indent | indent }}
+{%- set sname = (obj ~ "." ~ tdef.name) if obj else tdef.name %}
+{{- struct_serde(tdef.type(), (field_encoder, tag_encoder), sname, "rw") | indent | indent }}
 {%- else %}
 {{- field_encoder(tdef, (field_encoder, tag_encoder), obj, "rw") | indent | indent }}
 {%- endif %}


### PR DESCRIPTION
Two schemata fixes which are precursors to supporting KIP-951, but which
can go in first.

- kafka/schemata: preserve known tags received below their tagged version
- kafka/schemata: fix codegen for tagged struct fields outside arrays

Details in the commits.

<details><summary>.</summary>

Two fixes to the kafka message code generator's tagged-field handling,
split out of upcoming KIP-951 work (produce v10 / fetch v16, CORE-17155)
because both are latent today and only trigger once a schema defines a
tagged field whose taggedVersions minimum is above the message's first
flexible version, or a tagged struct outside an array element. The first
such fields (KIP-903 ReplicaState, KIP-951 CurrentLeader/NodeEndpoints)
arrive in the follow-up PRs.

The first commit is behavioral: a known tag id received below its
taggedVersions minimum is now consumed into the existing unknown-tags
mechanism (preserved and re-encoded byte-for-byte) instead of being
field-decoded with all reads version-skipped, which desynced the parse.
This keeps redpanda's existing tolerate-and-preserve behavior for such
bytes; Apache Kafka's generated decoder instead rejects them with "Tag N
is not valid for version". Found via the franz-go protocol compat test:
kmsg serializes tagged fields it knows about regardless of the
negotiated version.

The second commit fixes three compile-time template bugs for tagged
singular-struct fields at message top level (hardcoded array-element
object prefix in the decoder, unconditional prefix concatenation in the
encoder, and a member/type name-shadowing issue in the non-default
check). Generated output for existing schemas is unchanged apart from
the guards added by the first commit and the decltype spelling.

Tested with the franz-go round-trip harness (protocol_test) and the
codegen reproducibility test; each commit builds and passes
individually.

</details>

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v26.2.x
- [ ] v26.1.x
- [ ] v25.3.x

## Release Notes

* none

https://claude.ai/code/session_01A3MUR91Q3eZBceqeYTu4ce
