### PR TITLE
DNM: CORE-16997 verify ci-remote-cache activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,5 @@ docker pull docker.redpanda.com/redpandadata/redpanda-unstable:v25.1.1-rc1
 - [Upcoming Redpanda Events](https://www.redpanda.com/events)
 - [Redpanda Support](https://support.redpanda.com/)
 - [Redpanda University](https://university.redpanda.com/)
+
+<!-- CORE-16997: DNM, verifies the vtools ci-remote-cache activation. -->


### PR DESCRIPTION
Throwaway PR to verify [vtools#4457](https://github.com/redpanda-data/vtools/pull/4457) passes `--config=ci-remote-cache` through to bazel. Do not merge.

Based on current `dev`, which defines the config, so this exercises the positive path of the grep guard.

jira: [CORE-16997](https://redpandadata.atlassian.net/browse/CORE-16997)

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

[CORE-16997]: https://redpandadata.atlassian.net/browse/CORE-16997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ